### PR TITLE
Update message handling for project access updates, and update Helm deployment configuration

### DIFF
--- a/charts/lfx-v2-project-service/Chart.yaml
+++ b/charts/lfx-v2-project-service/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-project-service
 description: LFX Platform V2 Project Service chart
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "latest"

--- a/charts/lfx-v2-project-service/templates/deployment.yaml
+++ b/charts/lfx-v2-project-service/templates/deployment.yaml
@@ -25,6 +25,18 @@ spec:
           env:
             - name: NATS_URL
               value: {{ .Values.nats.url }}
+            - name: LOG_LEVEL
+              value: {{ .Values.app.logLevel }}
+            - name: LOG_ADD_SOURCE
+              value: {{ .Values.app.logAddSource | quote }}
+            - name: JWKS_URL
+              value: {{ .Values.heimdall.jwksUrl }}
+            - name: AUDIENCE
+              value: {{ .Values.app.audience }}
+            - name: SKIP_ETAG_VALIDATION
+              value: {{ .Values.app.skipEtagValidation | quote }}
+            - name: JWT_AUTH_DISABLED_MOCK_LOCAL_PRINCIPAL
+              value: {{ .Values.app.jwtAuthDisabledMockLocalPrincipal }}
           ports:
             - containerPort: 8080
               name: web

--- a/charts/lfx-v2-project-service/values.yaml
+++ b/charts/lfx-v2-project-service/values.yaml
@@ -19,6 +19,21 @@ initImage:
   # pullPolicy is the init container image pull policy
   pullPolicy: IfNotPresent
 
+# app is the configuration for the application
+app:
+  # logLevel is the log level (debug, info, warn, error)
+  logLevel: info
+  # logAddSource is a boolean to determine if the log source should be added
+  logAddSource: true
+  # audience is the JWT audience required for this authentication with this app
+  audience: lfx-v2-project-service
+  # skipEtagValidation is a boolean to determine if the etag validation should be skipped
+  # (only use for local development)
+  skipEtagValidation: false
+  # jwtAuthDisabledMockLocalPrincipal mocks auth for local development to use a set principal
+  # (only use for local development)
+  jwtAuthDisabledMockLocalPrincipal: ""
+
 # ingress is the configuration for the ingress routing
 ingress:
   # hostname is the hostname of the ingress
@@ -81,4 +96,6 @@ openfga:
 # heimdall is the configuration for the heimdall middleware
 heimdall:
   enabled: true
-  url: http://heimdall.lfx.svc.cluster.local:4456
+  url: http://lfx-platform-heimdall.lfx.svc.cluster.local:4456
+  # jwksUrl is the JWKS URL for JWT verification
+  jwksUrl: http://lfx-platform-heimdall.lfx.svc.cluster.local:4456/.well-known/jwks

--- a/cmd/project-api/service_endpoint_project.go
+++ b/cmd/project-api/service_endpoint_project.go
@@ -20,6 +20,8 @@ func handleError(err error) error {
 		return createResponse(http.StatusBadRequest, domain.ErrValidationFailed)
 	case domain.ErrRevisionMismatch:
 		return createResponse(http.StatusBadRequest, domain.ErrRevisionMismatch)
+	case domain.ErrInvalidParentProject:
+		return createResponse(http.StatusBadRequest, domain.ErrInvalidParentProject)
 	case domain.ErrProjectNotFound:
 		return createResponse(http.StatusNotFound, domain.ErrProjectNotFound)
 	case domain.ErrProjectSlugExists:

--- a/cmd/project-api/service_endpoint_project_test.go
+++ b/cmd/project-api/service_endpoint_project_test.go
@@ -150,7 +150,6 @@ func TestCreateProject(t *testing.T) {
 				mockMsg.On("SendIndexProject", mock.Anything, models.ActionCreated, mock.Anything).Return(nil)
 				mockMsg.On("SendUpdateAccessProject", mock.Anything, mock.Anything).Return(nil)
 				mockMsg.On("SendIndexProjectSettings", mock.Anything, models.ActionCreated, mock.Anything).Return(nil)
-				mockMsg.On("SendUpdateAccessProjectSettings", mock.Anything, mock.Anything).Return(nil)
 			},
 			expectedError: false,
 		},

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -9,6 +9,8 @@ import "errors"
 var (
 	// ErrProjectNotFound is returned when a project is not found.
 	ErrProjectNotFound = errors.New("project not found")
+	// ErrInvalidParentProject is returned when a parent project is invalid.
+	ErrInvalidParentProject = errors.New("invalid parent project")
 	// ErrProjectSlugExists is returned when a project slug already exists.
 	ErrProjectSlugExists = errors.New("project slug already exists")
 	// ErrInternal is returned when an internal error occurs.

--- a/internal/domain/message.go
+++ b/internal/domain/message.go
@@ -27,8 +27,6 @@ type MessageBuilder interface {
 	SendDeleteIndexProject(ctx context.Context, data string) error
 	SendIndexProjectSettings(ctx context.Context, action models.MessageAction, data models.ProjectSettings) error
 	SendDeleteIndexProjectSettings(ctx context.Context, data string) error
-	SendUpdateAccessProject(ctx context.Context, data models.ProjectBase) error
-	SendUpdateAccessProjectSettings(ctx context.Context, data models.ProjectSettings) error
+	SendUpdateAccessProject(ctx context.Context, data models.ProjectAccessMessage) error
 	SendDeleteAllAccessProject(ctx context.Context, data string) error
-	SendDeleteAllAccessProjectSettings(ctx context.Context, data string) error
 }

--- a/internal/domain/mock.go
+++ b/internal/domain/mock.go
@@ -132,22 +132,12 @@ func (m *MockMessageBuilder) SendDeleteIndexProjectSettings(ctx context.Context,
 	return args.Error(0)
 }
 
-func (m *MockMessageBuilder) SendUpdateAccessProject(ctx context.Context, data models.ProjectBase) error {
-	args := m.Called(ctx, data)
-	return args.Error(0)
-}
-
-func (m *MockMessageBuilder) SendUpdateAccessProjectSettings(ctx context.Context, data models.ProjectSettings) error {
+func (m *MockMessageBuilder) SendUpdateAccessProject(ctx context.Context, data models.ProjectAccessMessage) error {
 	args := m.Called(ctx, data)
 	return args.Error(0)
 }
 
 func (m *MockMessageBuilder) SendDeleteAllAccessProject(ctx context.Context, data string) error {
-	args := m.Called(ctx, data)
-	return args.Error(0)
-}
-
-func (m *MockMessageBuilder) SendDeleteAllAccessProjectSettings(ctx context.Context, data string) error {
 	args := m.Called(ctx, data)
 	return args.Error(0)
 }

--- a/internal/domain/models/message.go
+++ b/internal/domain/models/message.go
@@ -16,11 +16,21 @@ const (
 	ActionDeleted MessageAction = "deleted"
 )
 
-// ProjectMessage is a NATS message schema for sending messages related to projects CRUD operations.
-type ProjectMessage struct {
+// ProjectIndexerMessage is a NATS message schema for sending messages related to projects CRUD operations.
+type ProjectIndexerMessage struct {
 	Action  MessageAction     `json:"action"`
 	Headers map[string]string `json:"headers"`
 	Data    any               `json:"data"`
 	// Tags is a list of tags to be set on the indexed resource for search.
 	Tags []string `json:"tags"`
+}
+
+// ProjectAccessMessage is the schema for the data in the message sent to the fga-sync service.
+// These are the fields that the fga-sync service needs in order to update the OpenFGA permissions.
+type ProjectAccessMessage struct {
+	UID       string   `json:"uid"`
+	Public    bool     `json:"public"`
+	ParentUID string   `json:"parent_uid"`
+	Writers   []string `json:"writers"`
+	Auditors  []string `json:"auditors"`
 }

--- a/internal/domain/models/message_test.go
+++ b/internal/domain/models/message_test.go
@@ -39,15 +39,15 @@ func TestMessageActionConstants(t *testing.T) {
 	}
 }
 
-func TestProjectMessage(t *testing.T) {
+func TestProjectIndexerMessage(t *testing.T) {
 	tests := []struct {
 		name    string
-		message ProjectMessage
-		verify  func(t *testing.T, msg ProjectMessage)
+		message ProjectIndexerMessage
+		verify  func(t *testing.T, msg ProjectIndexerMessage)
 	}{
 		{
 			name: "project message with all fields",
-			message: ProjectMessage{
+			message: ProjectIndexerMessage{
 				Action: ActionCreated,
 				Headers: map[string]string{
 					"request-id": "test-request-123",
@@ -59,7 +59,7 @@ func TestProjectMessage(t *testing.T) {
 					"name": "Test Project",
 				},
 			},
-			verify: func(t *testing.T, msg ProjectMessage) {
+			verify: func(t *testing.T, msg ProjectIndexerMessage) {
 				assert.Equal(t, ActionCreated, msg.Action)
 				assert.Equal(t, "test-request-123", msg.Headers["request-id"])
 				assert.Equal(t, "user-456", msg.Headers["user-id"])
@@ -75,11 +75,11 @@ func TestProjectMessage(t *testing.T) {
 		},
 		{
 			name: "project message with minimal fields",
-			message: ProjectMessage{
+			message: ProjectIndexerMessage{
 				Action: ActionDeleted,
 				Data:   "simple-data",
 			},
-			verify: func(t *testing.T, msg ProjectMessage) {
+			verify: func(t *testing.T, msg ProjectIndexerMessage) {
 				assert.Equal(t, ActionDeleted, msg.Action)
 				assert.Nil(t, msg.Headers)
 				assert.Equal(t, "simple-data", msg.Data)
@@ -87,14 +87,14 @@ func TestProjectMessage(t *testing.T) {
 		},
 		{
 			name: "project message with nil data",
-			message: ProjectMessage{
+			message: ProjectIndexerMessage{
 				Action: ActionUpdated,
 				Headers: map[string]string{
 					"correlation-id": "corr-123",
 				},
 				Data: nil,
 			},
-			verify: func(t *testing.T, msg ProjectMessage) {
+			verify: func(t *testing.T, msg ProjectIndexerMessage) {
 				assert.Equal(t, ActionUpdated, msg.Action)
 				assert.Equal(t, "corr-123", msg.Headers["correlation-id"])
 				assert.Nil(t, msg.Data)
@@ -102,7 +102,7 @@ func TestProjectMessage(t *testing.T) {
 		},
 		{
 			name: "project message with complex data structure",
-			message: ProjectMessage{
+			message: ProjectIndexerMessage{
 				Action: ActionCreated,
 				Data: struct {
 					ProjectUID string   `json:"project_uid"`
@@ -123,7 +123,7 @@ func TestProjectMessage(t *testing.T) {
 					},
 				},
 			},
-			verify: func(t *testing.T, msg ProjectMessage) {
+			verify: func(t *testing.T, msg ProjectIndexerMessage) {
 				assert.Equal(t, ActionCreated, msg.Action)
 				assert.NotNil(t, msg.Data)
 				// Verify the data structure is preserved
@@ -174,15 +174,15 @@ func TestMessageActionString(t *testing.T) {
 	}
 }
 
-func TestProjectMessageValidation(t *testing.T) {
+func TestProjectIndexerMessageValidation(t *testing.T) {
 	tests := []struct {
 		name    string
-		message ProjectMessage
+		message ProjectIndexerMessage
 		isValid bool
 	}{
 		{
 			name: "valid message with required fields",
-			message: ProjectMessage{
+			message: ProjectIndexerMessage{
 				Action: ActionCreated,
 				Data:   "some-data",
 			},
@@ -190,7 +190,7 @@ func TestProjectMessageValidation(t *testing.T) {
 		},
 		{
 			name: "valid message with all fields",
-			message: ProjectMessage{
+			message: ProjectIndexerMessage{
 				Action: ActionUpdated,
 				Headers: map[string]string{
 					"key": "value",
@@ -203,7 +203,7 @@ func TestProjectMessageValidation(t *testing.T) {
 		},
 		{
 			name: "message with empty action",
-			message: ProjectMessage{
+			message: ProjectIndexerMessage{
 				Action: "",
 				Data:   "some-data",
 			},
@@ -211,7 +211,7 @@ func TestProjectMessageValidation(t *testing.T) {
 		},
 		{
 			name: "message with unknown action",
-			message: ProjectMessage{
+			message: ProjectIndexerMessage{
 				Action: MessageAction("unknown"),
 				Data:   "some-data",
 			},

--- a/internal/infrastructure/nats/message.go
+++ b/internal/infrastructure/nats/message.go
@@ -71,7 +71,7 @@ func (m *MessageBuilder) sendIndexerMessage(ctx context.Context, subject string,
 
 	// TODO: use the model from the indexer service to keep the message body consistent.
 	// Ticket https://linuxfoundation.atlassian.net/browse/LFXV2-147
-	message := models.ProjectMessage{
+	message := models.ProjectIndexerMessage{
 		Action:  action,
 		Headers: headers,
 		Data:    payload,
@@ -131,7 +131,7 @@ func (m *MessageBuilder) SendDeleteIndexProjectSettings(ctx context.Context, dat
 }
 
 // SendUpdateAccessProject sends the message to the NATS server for the access control updates.
-func (m *MessageBuilder) SendUpdateAccessProject(ctx context.Context, data models.ProjectBase) error {
+func (m *MessageBuilder) SendUpdateAccessProject(ctx context.Context, data models.ProjectAccessMessage) error {
 	dataBytes, err := json.Marshal(data)
 	if err != nil {
 		slog.ErrorContext(ctx, "error marshalling data into JSON", constants.ErrKey, err)
@@ -141,23 +141,7 @@ func (m *MessageBuilder) SendUpdateAccessProject(ctx context.Context, data model
 	return m.sendMessage(ctx, constants.UpdateAccessProjectSubject, dataBytes)
 }
 
-// SendUpdateAccessProjectSettings sends the message to the NATS server for the access control updates.
-func (m *MessageBuilder) SendUpdateAccessProjectSettings(ctx context.Context, data models.ProjectSettings) error {
-	dataBytes, err := json.Marshal(data)
-	if err != nil {
-		slog.ErrorContext(ctx, "error marshalling data into JSON", constants.ErrKey, err)
-		return err
-	}
-
-	return m.sendMessage(ctx, constants.UpdateAccessProjectSettingsSubject, dataBytes)
-}
-
 // SendDeleteAllAccessProject sends the message to the NATS server for the access control deletion.
 func (m *MessageBuilder) SendDeleteAllAccessProject(ctx context.Context, data string) error {
 	return m.sendMessage(ctx, constants.DeleteAllAccessSubject, []byte(data))
-}
-
-// SendDeleteAllAccessProjectSettings sends the message to the NATS server for the access control deletion.
-func (m *MessageBuilder) SendDeleteAllAccessProjectSettings(ctx context.Context, data string) error {
-	return m.sendMessage(ctx, constants.DeleteAllAccessProjectSettingsSubject, []byte(data))
 }

--- a/internal/infrastructure/nats/message_test.go
+++ b/internal/infrastructure/nats/message_test.go
@@ -35,7 +35,7 @@ func TestMessageBuilder_SendIndexProject(t *testing.T) {
 			data:   models.ProjectBase{UID: "test-project"},
 			setupMocks: func(mockConn *MockNATSConn) {
 				mockConn.On("Publish", constants.IndexProjectSubject, mock.MatchedBy(func(data []byte) bool {
-					var msg models.ProjectMessage
+					var msg models.ProjectIndexerMessage
 					err := json.Unmarshal(data, &msg)
 					if err != nil {
 						return false
@@ -57,7 +57,7 @@ func TestMessageBuilder_SendIndexProject(t *testing.T) {
 			data:   models.ProjectBase{UID: "test-project"},
 			setupMocks: func(mockConn *MockNATSConn) {
 				mockConn.On("Publish", constants.IndexProjectSubject, mock.MatchedBy(func(data []byte) bool {
-					var msg models.ProjectMessage
+					var msg models.ProjectIndexerMessage
 					err := json.Unmarshal(data, &msg)
 					if err != nil {
 						return false
@@ -74,7 +74,7 @@ func TestMessageBuilder_SendIndexProject(t *testing.T) {
 			data:   models.ProjectBase{UID: "test-uid", Name: "Test Project", Slug: "test-project", Description: "Test Description"},
 			setupMocks: func(mockConn *MockNATSConn) {
 				mockConn.On("Publish", constants.IndexProjectSubject, mock.MatchedBy(func(data []byte) bool {
-					var msg models.ProjectMessage
+					var msg models.ProjectIndexerMessage
 					err := json.Unmarshal(data, &msg)
 					if err != nil {
 						return false
@@ -143,7 +143,7 @@ func TestMessageBuilder_SendIndexProjectSettings(t *testing.T) {
 			data:   models.ProjectSettings{UID: "test-project"},
 			setupMocks: func(mockConn *MockNATSConn) {
 				mockConn.On("Publish", constants.IndexProjectSettingsSubject, mock.MatchedBy(func(data []byte) bool {
-					var msg models.ProjectMessage
+					var msg models.ProjectIndexerMessage
 					err := json.Unmarshal(data, &msg)
 					return err == nil && msg.Action == models.ActionCreated
 				})).Return(nil)
@@ -156,7 +156,7 @@ func TestMessageBuilder_SendIndexProjectSettings(t *testing.T) {
 			data:   models.ProjectSettings{UID: "test-uid", MissionStatement: "Test Mission"},
 			setupMocks: func(mockConn *MockNATSConn) {
 				mockConn.On("Publish", constants.IndexProjectSettingsSubject, mock.MatchedBy(func(data []byte) bool {
-					var msg models.ProjectMessage
+					var msg models.ProjectIndexerMessage
 					err := json.Unmarshal(data, &msg)
 					if err != nil {
 						return false
@@ -202,100 +202,6 @@ func TestMessageBuilder_SendIndexProjectSettings(t *testing.T) {
 	}
 }
 
-func TestMessageBuilder_SendUpdateAccessProject(t *testing.T) {
-	tests := []struct {
-		name       string
-		data       models.ProjectBase
-		setupMocks func(*MockNATSConn)
-		wantErr    bool
-	}{
-		{
-			name: "successful send update access project message",
-			data: models.ProjectBase{UID: "test-project"},
-			setupMocks: func(mockConn *MockNATSConn) {
-				mockConn.On("Publish", constants.UpdateAccessProjectSubject, mock.Anything).Return(nil)
-			},
-			wantErr: false,
-		},
-		{
-			name: "nats publish error",
-			data: models.ProjectBase{UID: "test-project"},
-			setupMocks: func(mockConn *MockNATSConn) {
-				mockConn.On("Publish", constants.UpdateAccessProjectSubject, mock.Anything).Return(errors.New("publish failed"))
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockConn := &MockNATSConn{}
-			tt.setupMocks(mockConn)
-
-			builder := &MessageBuilder{
-				NatsConn: mockConn,
-			}
-
-			err := builder.SendUpdateAccessProject(context.Background(), tt.data)
-
-			if tt.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-
-			mockConn.AssertExpectations(t)
-		})
-	}
-}
-
-func TestMessageBuilder_SendUpdateAccessProjectSettings(t *testing.T) {
-	tests := []struct {
-		name       string
-		data       models.ProjectSettings
-		setupMocks func(*MockNATSConn)
-		wantErr    bool
-	}{
-		{
-			name: "successful send update access project settings message",
-			data: models.ProjectSettings{UID: "test-project"},
-			setupMocks: func(mockConn *MockNATSConn) {
-				mockConn.On("Publish", constants.UpdateAccessProjectSettingsSubject, mock.Anything).Return(nil)
-			},
-			wantErr: false,
-		},
-		{
-			name: "nats publish error",
-			data: models.ProjectSettings{UID: "test-project"},
-			setupMocks: func(mockConn *MockNATSConn) {
-				mockConn.On("Publish", constants.UpdateAccessProjectSettingsSubject, mock.Anything).Return(errors.New("publish failed"))
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockConn := &MockNATSConn{}
-			tt.setupMocks(mockConn)
-
-			builder := &MessageBuilder{
-				NatsConn: mockConn,
-			}
-
-			err := builder.SendUpdateAccessProjectSettings(context.Background(), tt.data)
-
-			if tt.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-
-			mockConn.AssertExpectations(t)
-		})
-	}
-}
-
 func TestMessageBuilder_SendDeleteIndexProject(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -309,7 +215,7 @@ func TestMessageBuilder_SendDeleteIndexProject(t *testing.T) {
 			data: "test-project-uid",
 			setupMocks: func(mockConn *MockNATSConn) {
 				mockConn.On("Publish", constants.IndexProjectSubject, mock.MatchedBy(func(data []byte) bool {
-					var msg models.ProjectMessage
+					var msg models.ProjectIndexerMessage
 					err := json.Unmarshal(data, &msg)
 					if err != nil {
 						return false
@@ -370,7 +276,7 @@ func TestMessageBuilder_SendDeleteIndexProjectSettings(t *testing.T) {
 			data: "test-project-uid",
 			setupMocks: func(mockConn *MockNATSConn) {
 				mockConn.On("Publish", constants.IndexProjectSettingsSubject, mock.MatchedBy(func(data []byte) bool {
-					var msg models.ProjectMessage
+					var msg models.ProjectIndexerMessage
 					err := json.Unmarshal(data, &msg)
 					if err != nil {
 						return false
@@ -400,6 +306,53 @@ func TestMessageBuilder_SendDeleteIndexProjectSettings(t *testing.T) {
 			}
 
 			err := builder.SendDeleteIndexProjectSettings(context.Background(), tt.data)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockConn.AssertExpectations(t)
+		})
+	}
+}
+
+func TestMessageBuilder_SendUpdateAccessProject(t *testing.T) {
+	tests := []struct {
+		name       string
+		data       models.ProjectAccessMessage
+		setupMocks func(*MockNATSConn)
+		wantErr    bool
+	}{
+		{
+			name: "successful send update access project message",
+			data: models.ProjectAccessMessage{UID: "test-project"},
+			setupMocks: func(mockConn *MockNATSConn) {
+				mockConn.On("Publish", constants.UpdateAccessProjectSubject, mock.Anything).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "nats publish error",
+			data: models.ProjectAccessMessage{UID: "test-project"},
+			setupMocks: func(mockConn *MockNATSConn) {
+				mockConn.On("Publish", constants.UpdateAccessProjectSubject, mock.Anything).Return(errors.New("publish failed"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockConn := &MockNATSConn{}
+			tt.setupMocks(mockConn)
+
+			builder := &MessageBuilder{
+				NatsConn: mockConn,
+			}
+
+			err := builder.SendUpdateAccessProject(context.Background(), tt.data)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -459,53 +412,6 @@ func TestMessageBuilder_SendDeleteAllAccessProject(t *testing.T) {
 	}
 }
 
-func TestMessageBuilder_SendDeleteAllAccessProjectSettings(t *testing.T) {
-	tests := []struct {
-		name       string
-		data       string
-		setupMocks func(*MockNATSConn)
-		wantErr    bool
-	}{
-		{
-			name: "successful send delete all access project settings message",
-			data: "test-project",
-			setupMocks: func(mockConn *MockNATSConn) {
-				mockConn.On("Publish", constants.DeleteAllAccessProjectSettingsSubject, []byte("test-project")).Return(nil)
-			},
-			wantErr: false,
-		},
-		{
-			name: "nats publish error",
-			data: "test-project",
-			setupMocks: func(mockConn *MockNATSConn) {
-				mockConn.On("Publish", constants.DeleteAllAccessProjectSettingsSubject, mock.Anything).Return(errors.New("publish failed"))
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockConn := &MockNATSConn{}
-			tt.setupMocks(mockConn)
-
-			builder := &MessageBuilder{
-				NatsConn: mockConn,
-			}
-
-			err := builder.SendDeleteAllAccessProjectSettings(context.Background(), tt.data)
-
-			if tt.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-
-			mockConn.AssertExpectations(t)
-		})
-	}
-}
-
 func TestMessageBuilder_ContextHandling(t *testing.T) {
 	t.Run("extracts authorization and principal from context", func(t *testing.T) {
 		mockConn := &MockNATSConn{}
@@ -514,7 +420,7 @@ func TestMessageBuilder_ContextHandling(t *testing.T) {
 		expectedPrincipal := "user456"
 
 		mockConn.On("Publish", constants.IndexProjectSubject, mock.MatchedBy(func(data []byte) bool {
-			var msg models.ProjectMessage
+			var msg models.ProjectIndexerMessage
 			err := json.Unmarshal(data, &msg)
 			if err != nil {
 				return false
@@ -542,7 +448,7 @@ func TestMessageBuilder_ContextHandling(t *testing.T) {
 		mockConn := &MockNATSConn{}
 
 		mockConn.On("Publish", constants.IndexProjectSubject, mock.MatchedBy(func(data []byte) bool {
-			var msg models.ProjectMessage
+			var msg models.ProjectIndexerMessage
 			err := json.Unmarshal(data, &msg)
 			if err != nil {
 				return false

--- a/internal/infrastructure/nats/repository.go
+++ b/internal/infrastructure/nats/repository.go
@@ -104,7 +104,6 @@ func (s *NatsRepository) GetProjectUIDFromSlug(ctx context.Context, projectSlug 
 	entry, err = s.Projects.Get(ctx, fmt.Sprintf("slug/%s", projectSlug))
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			slog.WarnContext(ctx, "project not found", constants.ErrKey, err)
 			return "", domain.ErrProjectNotFound
 		}
 		slog.ErrorContext(ctx, "error getting project from NATS KV store", constants.ErrKey, err)

--- a/internal/service/project_operations_test.go
+++ b/internal/service/project_operations_test.go
@@ -154,7 +154,6 @@ func TestProjectsService_CreateProject(t *testing.T) {
 				mockBuilder.On("SendIndexProject", mock.Anything, models.ActionCreated, mock.Anything).Return(nil)
 				mockBuilder.On("SendUpdateAccessProject", mock.Anything, mock.Anything).Return(nil)
 				mockBuilder.On("SendIndexProjectSettings", mock.Anything, models.ActionCreated, mock.Anything).Return(nil)
-				mockBuilder.On("SendUpdateAccessProjectSettings", mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: false,
 			validate: func(t *testing.T, result *projsvc.ProjectFull) {


### PR DESCRIPTION
As a follow up to https://github.com/linuxfoundation/lfx-v2-project-service/pull/2, there was a bug introduced where the project access isn't updated properly by the fga-sync service (https://github.com/linuxfoundation/lfx-v2-fga-sync) because the payload passed by the project service was incomplete. This service was sending a separate NATS message for project settings access updates with the `writers` and `auditors` attributes, even though the fga-sync service doesn't handle that message. This service should instead only send messages for project access updates and include all of the attributes that the fga-sync needs. There is a [ticket](https://linuxfoundation.atlassian.net/browse/LFXV2-147) to consolidate the payload schema between the fga-sync service and project service so there isn't confusion about the expected payload going forward.

--

Service changes:
- Add ProjectAccessMessage model for structured access control updates
- Update SendUpdateAccessProject to use new message structure
- Update SendDeleteAllAccessProject to take string UID parameter
- Rename ProjectMessage to ProjectIndexerMessage for clarity
- Update all tests to use new message models

Helm chart updates:
- Add SKIP_ETAG_VALIDATION environment variable to deployment, among other environment variables from the application configuration
- Fix boolean-to-string conversion for env vars using quote function
- Add app configuration section in values.yaml

Assisted by [Claude Code](https://claude.ai/code)