### PR TITLE
fix: Remove namespace from middleware settings

### DIFF
--- a/charts/lfx-v2-project-service/Chart.yaml
+++ b/charts/lfx-v2-project-service/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-project-service
 description: LFX Platform V2 Project Service chart
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "latest"

--- a/charts/lfx-v2-project-service/templates/httproute.yaml
+++ b/charts/lfx-v2-project-service/templates/httproute.yaml
@@ -28,7 +28,6 @@ spec:
         group: traefik.io
         kind: Middleware
         name: heimdall
-        namespace: {{ .Values.traefik.gateway.namespace }}
     {{- end }}
     backendRefs:
     - name: lfx-v2-project-service


### PR DESCRIPTION
'namespace' isn't a valid key for extentionRefs. See:
https://gateway-api.sigs.k8s.io/reference/spec/#localobjectreference

Also bumps the chart version to 0.3.1

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>
