### PR TITLE
fix commenting on ruleset.yaml

### DIFF
--- a/charts/lfx-v2-project-service/templates/ruleset.yaml
+++ b/charts/lfx-v2-project-service/templates/ruleset.yaml
@@ -47,9 +47,11 @@ spec:
             values:
               relation: writer
               object: "project:{{ "{{- .Request.Body.parent_uid -}}" }}"
-        {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{- else }}
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -96,9 +98,11 @@ spec:
             values:
               relation: viewer
               object: "project:{{ "{{- .Request.URL.Captures.id -}}" }}"
-        {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{- else }}
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -124,9 +128,11 @@ spec:
             values:
               relation: writer
               object: "project:{{ "{{- .Request.URL.Captures.id -}}" }}"
-        {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{- else }}
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -152,9 +158,11 @@ spec:
             values:
               relation: owner
               object: "project:{{ "{{- .Request.URL.Captures.id -}}" }}"
-        {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{- else }}
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+       */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -180,9 +188,11 @@ spec:
             values:
               relation: auditor
               object: "project:{{ "{{- .Request.URL.Captures.id -}}" }}"
-        {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{- else }}
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -208,9 +218,11 @@ spec:
             values:
               relation: writer
               object: "project:{{ "{{- .Request.URL.Captures.id -}}" }}"
-        {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{- else }}
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt


### PR DESCRIPTION
the yaml comments were being inlined as part of the string on the line above, not a proper comment. The else clause has been fixed to prevent this.

However, the comment *also* gets thrown away, so change it over to a helm template comment instead since that is the only place it will be seen.