### PR TITLE
feat: add configurable writers and auditors for root project init container

### DIFF
--- a/charts/lfx-v2-project-service/templates/deployment.yaml
+++ b/charts/lfx-v2-project-service/templates/deployment.yaml
@@ -65,3 +65,7 @@ spec:
           env:
             - name: NATS_URL
               value: {{ .Values.nats.url }}
+            - name: ROOT_PROJECT_WRITERS
+              value: {{ .Values.rootProject.writers | join "," }}
+            - name: ROOT_PROJECT_AUDITORS
+              value: {{ .Values.rootProject.auditors | join "," }}

--- a/charts/lfx-v2-project-service/values.yaml
+++ b/charts/lfx-v2-project-service/values.yaml
@@ -55,6 +55,15 @@ service:
   # port is the service port
   port: 8080
 
+# rootProject is the configuration for the root project creation
+rootProject:
+  # writers is a list of user/principal identifiers that should have writer access to the root project
+  writers:
+    - project_super_admin
+  # auditors is a list of user/principal identifiers that should have auditor access to the root project
+  auditors:
+    - project_admin_1
+
 # nats is the configuration for the NATS server
 nats:
   # url is the URL of the NATS server


### PR DESCRIPTION

- Update root project setup script to accept ROOT_PROJECT_WRITERS and ROOT_PROJECT_AUDITORS environment variables
- Parse comma-separated values and assign to root project settings
- Send NATS index messages for created root project using existing MessageBuilder infrastructure
- Add Helm configuration for rootProject.writers and rootProject.auditors arrays
- Update deployment template to pass environment variables to init container

🤖 Generated with [Claude Code](https://claude.ai/code)