### PR TITLE
[LFXV2-596] Add NATS handler for getting project logo by UID

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,7 @@ Complete API endpoint documentation and NATS message handlers are now documented
 "lfx.projects-api.queue"               // Queue for projects API operations
 "lfx.projects-api.get_name"            // Get project name by UID
 "lfx.projects-api.get_slug"            // Get project slug by UID
+"lfx.projects-api.get_logo"            // Get project logo URL by UID
 "lfx.projects-api.slug_to_uid"         // Convert slug to UID
 
 // Outbound events (published by this service)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This service handles the following NATS subjects for inter-service communication
 
 - `lfx.projects-api.get_name`: Get a project name from a given project UID
 - `lfx.projects-api.get_slug`: Get a project slug from a given project UID
+- `lfx.projects-api.get_logo`: Get a project logo URL from a given project UID
 - `lfx.projects-api.slug_to_uid`: Get a project UID from a given project slug
 
 ### Project Tags
@@ -62,7 +63,7 @@ Project settings generate a separate set of tags:
 Tags serve multiple important purposes in the LFX system:
 
 1. **Indexed Search**: Tags are indexed in OpenSearch, enabling fast lookups and text searches across projects
-   
+
 2. **Relationship Navigation**: Parent-child relationships can be traversed using the parent_uid tags
 
 3. **Multiple Access Patterns**: Both plain value and prefixed tags support different query patterns:
@@ -313,7 +314,6 @@ Copyright The Linux Foundation and each contributor to LFX.
 This project’s source code is licensed under the MIT License. A copy of the
 license is available in `LICENSE`.
 
-This project’s documentation is licensed under the Creative Commons Attribution
+This project's documentation is licensed under the Creative Commons Attribution
 4.0 International License \(CC-BY-4.0\). A copy of the license is available in
 `LICENSE-docs`.
-

--- a/cmd/project-api/main.go
+++ b/cmd/project-api/main.go
@@ -327,6 +327,8 @@ func createNatsSubcriptions(ctx context.Context, svc *ProjectsAPI, natsConn *nat
 		constants.ProjectGetNameSubject,
 		// Get project slug subscription
 		constants.ProjectGetSlugSubject,
+		// Get project logo subscription
+		constants.ProjectGetLogoSubject,
 		// Get project slug to UID subscription
 		constants.ProjectSlugToUIDSubject,
 	} {

--- a/internal/service/project_handlers.go
+++ b/internal/service/project_handlers.go
@@ -27,6 +27,7 @@ func (s *ProjectsService) HandleMessage(ctx context.Context, msg domain.Message)
 	handlers := map[string]func(ctx context.Context, msg domain.Message) ([]byte, error){
 		constants.ProjectGetNameSubject:   s.HandleProjectGetName,
 		constants.ProjectGetSlugSubject:   s.HandleProjectGetSlug,
+		constants.ProjectGetLogoSubject:   s.HandleProjectGetLogo,
 		constants.ProjectSlugToUIDSubject: s.HandleProjectSlugToUID,
 	}
 
@@ -110,6 +111,11 @@ func (s *ProjectsService) HandleProjectGetName(ctx context.Context, msg domain.M
 // HandleProjectGetSlug is the message handler for the project-get-slug subject.
 func (s *ProjectsService) HandleProjectGetSlug(ctx context.Context, msg domain.Message) ([]byte, error) {
 	return s.handleProjectGetAttribute(ctx, msg, constants.ProjectGetSlugSubject, "slug")
+}
+
+// HandleProjectGetLogo is the message handler for the project-get-logo subject.
+func (s *ProjectsService) HandleProjectGetLogo(ctx context.Context, msg domain.Message) ([]byte, error) {
+	return s.handleProjectGetAttribute(ctx, msg, constants.ProjectGetLogoSubject, "logo_url")
 }
 
 // HandleProjectSlugToUID is the message handler for the project-slug-to-uid subject.

--- a/internal/service/project_handlers_test.go
+++ b/internal/service/project_handlers_test.go
@@ -65,6 +65,25 @@ func TestProjectsService_HandleMessage(t *testing.T) {
 			expectCalls: true,
 		},
 		{
+			name:        "handle project get logo message",
+			subject:     constants.ProjectGetLogoSubject,
+			messageData: []byte("01234567-89ab-cdef-0123-456789abcdef"),
+			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
+				now := time.Now()
+				mockRepo.On("GetProjectBase", mock.Anything, "01234567-89ab-cdef-0123-456789abcdef").Return(
+					&models.ProjectBase{
+						UID:       "01234567-89ab-cdef-0123-456789abcdef",
+						Name:      "Test Project",
+						LogoURL:   "https://example.com/logo.png",
+						CreatedAt: &now,
+						UpdatedAt: &now,
+					},
+					nil,
+				)
+			},
+			expectCalls: true,
+		},
+		{
 			name:        "handle project slug to UID message",
 			subject:     constants.ProjectSlugToUIDSubject,
 			messageData: []byte("test-project"),
@@ -271,6 +290,91 @@ func TestProjectsService_HandleProjectGetSlug(t *testing.T) {
 			mockMsg := newMockMessage(constants.ProjectGetSlugSubject, tt.messageData)
 
 			response, err := service.HandleProjectGetSlug(ctx, mockMsg)
+
+			if tt.expectedErr {
+				assert.Error(t, err)
+				assert.Nil(t, response)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, response)
+				if tt.validate != nil {
+					tt.validate(t, response)
+				}
+			}
+
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestProjectsService_HandleProjectGetLogo(t *testing.T) {
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		messageData []byte
+		setupMocks  func(*domain.MockProjectRepository)
+		expectedErr bool
+		validate    func(*testing.T, []byte)
+	}{
+		{
+			name:        "successful get project logo",
+			messageData: []byte("01234567-89ab-cdef-0123-456789abcdef"),
+			setupMocks: func(mockRepo *domain.MockProjectRepository) {
+				now := time.Now()
+				mockRepo.On("GetProjectBase", mock.Anything, "01234567-89ab-cdef-0123-456789abcdef").Return(
+					&models.ProjectBase{
+						UID:       "01234567-89ab-cdef-0123-456789abcdef",
+						Name:      "Test Project Name",
+						LogoURL:   "https://example.com/logo.png",
+						CreatedAt: &now,
+						UpdatedAt: &now,
+					},
+					nil,
+				)
+			},
+			expectedErr: false,
+			validate: func(t *testing.T, response []byte) {
+				assert.Equal(t, "https://example.com/logo.png", string(response))
+			},
+		},
+		{
+			name:        "project not found",
+			messageData: []byte("01234567-89ab-cdef-0123-456789abcd00"),
+			setupMocks: func(mockRepo *domain.MockProjectRepository) {
+				mockRepo.On("GetProjectBase", mock.Anything, "01234567-89ab-cdef-0123-456789abcd00").Return(
+					nil, domain.ErrProjectNotFound,
+				)
+			},
+			expectedErr: true,
+		},
+		{
+			name:        "invalid UUID format",
+			messageData: []byte("invalid-uuid-format"),
+			setupMocks: func(mockRepo *domain.MockProjectRepository) {
+				// No repo calls expected for invalid UUID
+			},
+			expectedErr: true,
+		},
+		{
+			name:        "empty project UID",
+			messageData: []byte(""),
+			setupMocks: func(mockRepo *domain.MockProjectRepository) {
+				// No repo calls expected for empty UID
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service, mockRepo, _, _ := setupServiceForTesting()
+			tt.setupMocks(mockRepo)
+
+			mockMsg := newMockMessage(constants.ProjectGetLogoSubject, tt.messageData)
+
+			response, err := service.HandleProjectGetLogo(ctx, mockMsg)
 
 			if tt.expectedErr {
 				assert.Error(t, err)

--- a/pkg/constants/nats.go
+++ b/pkg/constants/nats.go
@@ -54,6 +54,9 @@ const (
 	// ProjectGetSlugSubject is the subject for the project get slug.
 	// The subject is of the form: lfx.projects-api.get_slug
 	ProjectGetSlugSubject = "lfx.projects-api.get_slug"
+	// ProjectGetLogoSubject is the subject for the project get logo.
+	// The subject is of the form: lfx.projects-api.get_logo
+	ProjectGetLogoSubject = "lfx.projects-api.get_logo"
 	// ProjectSlugToUIDSubject is the subject for the project slug to UID.
 	// The subject is of the form: lfx.projects-api.slug_to_uid
 	ProjectSlugToUIDSubject = "lfx.projects-api.slug_to_uid"


### PR DESCRIPTION
## Summary

- Added new NATS message handler for retrieving project logo URLs by project UID
- Follows existing pattern used for `get_name` and `get_slug` handlers
- New subject: `lfx.projects-api.get_logo`

## Changes

- Added `ProjectGetLogoSubject` constant for `lfx.projects-api.get_logo`
- Implemented `HandleProjectGetLogo` handler that retrieves `logo_url` field from project base
- Registered new subject in NATS subscriptions
- Added comprehensive test coverage including success and error cases
- Updated documentation in README.md and CLAUDE.md

## Test plan

- [x] Unit tests pass for `HandleProjectGetLogo`
- [x] Integration test in `HandleMessage` includes logo handler
- [x] Build completes successfully
- [x] Linting passes

## Ticket

[LFXV2-596](https://linuxfoundation.atlassian.net/browse/LFXV2-596)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-596]: https://linuxfoundation.atlassian.net/browse/LFXV2-596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ