### PR TITLE
feat: add configurable JWT signature algorithm support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,9 @@ export JWKS_URL=http://lfx-platform-heimdall.lfx.svc.cluster.local:4457/.well-kn
 # JWT audience
 export AUDIENCE=lfx-v2-project-service
 
+# JWT signature algorithm (PS256, PS384, PS512, RS256, RS384, RS512, ES256, ES384, ES512)
+export JWT_SIGNATURE_ALGORITHM=PS256
+
 # Skip the ETag validation that requires the correct revision on PUT/DELETE requests.
 # When this is set to false, it means you need to make a GET request on the resource
 # to get the ETag response header and use it as the ETag request header on the PUT/DELETE

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,7 @@ func TestEndpoint(t *testing.T) {
 | `JWKS_URL` | JWT verification endpoint | - | No |
 | `AUDIENCE` | JWT audience | lfx-v2-project-service | No |
 | `JWT_AUTH_DISABLED_MOCK_LOCAL_PRINCIPAL` | Mock auth for local dev | - | No |
+| `JWT_SIGNATURE_ALGORITHM` | JWT signature algorithm | PS256 | No |
 
 ## Authorization (OpenFGA)
 

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ help:
 deps:
 	@echo "==> Installing dependencies..."
 	go mod download
-	go install goa.design/goa/$(GOA_VERSION)/cmd/goa@latest
+	go install goa.design/goa/$(GOA_VERSION)/cmd/goa@v3.22.6
 	@command -v golangci-lint >/dev/null 2>&1 || { \
 		echo "==> Installing golangci-lint..."; \
 		go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest; \

--- a/charts/lfx-v2-project-service/Chart.yaml
+++ b/charts/lfx-v2-project-service/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-project-service
 description: LFX Platform V2 Project Service chart
 type: application
-version: 0.5.3
+version: 0.5.4
 appVersion: "latest"

--- a/charts/lfx-v2-project-service/templates/deployment.yaml
+++ b/charts/lfx-v2-project-service/templates/deployment.yaml
@@ -37,6 +37,8 @@ spec:
               value: {{ .Values.app.skipEtagValidation | quote }}
             - name: JWT_AUTH_DISABLED_MOCK_LOCAL_PRINCIPAL
               value: {{ .Values.app.jwtAuthDisabledMockLocalPrincipal }}
+            - name: JWT_SIGNATURE_ALGORITHM
+              value: {{ .Values.app.jwtSignatureAlgorithm }}
           ports:
             - containerPort: {{ .Values.service.port }}
               name: web

--- a/charts/lfx-v2-project-service/values.yaml
+++ b/charts/lfx-v2-project-service/values.yaml
@@ -47,6 +47,10 @@ app:
   # jwtAuthDisabledMockLocalPrincipal mocks auth for local development to use a set principal
   # (only use for local development)
   jwtAuthDisabledMockLocalPrincipal: ""
+  # jwtSignatureAlgorithm is the JWT signature algorithm for token validation
+  # Supported: PS256 (default), PS384, PS512, RS256, RS384, RS512, ES256, ES384, ES512
+  # Algorithm names are case-sensitive and must be uppercase
+  jwtSignatureAlgorithm: "PS256"
   # use_oidc_contextualizer is a boolean to determine if the OIDC contextualizer should be used
   use_oidc_contextualizer: true
 

--- a/cmd/project-api/main.go
+++ b/cmd/project-api/main.go
@@ -51,6 +51,7 @@ func main() {
 		JWKSURL:            os.Getenv("JWKS_URL"),
 		Audience:           os.Getenv("AUDIENCE"),
 		MockLocalPrincipal: os.Getenv("JWT_AUTH_DISABLED_MOCK_LOCAL_PRINCIPAL"),
+		SignatureAlgorithm: os.Getenv("JWT_SIGNATURE_ALGORITHM"),
 	}
 	jwtAuth, err := auth.NewJWTAuth(jwtAuthConfig)
 	if err != nil {


### PR DESCRIPTION
Add support for JWT_SIGNATURE_ALGORITHM environment variable to allow operators to configure the JWT signature algorithm for token validation.

Fixes: LFXV2-914

Changes:
- Add parseSignatureAlgorithm() function to validate and map algorithm strings
- Extend JWTAuthConfig struct with SignatureAlgorithm field
- Update NewJWTAuth() to use configured algorithm with logging for non-defaults
- Support 9 algorithms: PS256/384/512, RS256/384/512, ES256/384/512
- Add comprehensive test coverage (18 test cases) for algorithm validation
- Update Helm chart (v0.5.3 -> v0.5.4) with jwtSignatureAlgorithm configuration
- Add JWT_SIGNATURE_ALGORITHM to deployment template
- Update documentation (CLAUDE.md, .env.example)

Default behavior:
- PS256 remains the default algorithm when env var is not set
- Backward compatible with existing deployments
- Case-sensitive algorithm names (uppercase required)
- Fails fast at startup for invalid algorithm configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)