### PR TITLE
Annotate kv buckets for backstage discovery

### DIFF
--- a/charts/lfx-v2-project-service/templates/nats-kv-buckets.yaml
+++ b/charts/lfx-v2-project-service/templates/nats-kv-buckets.yaml
@@ -11,6 +11,8 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
 spec:
   bucket: {{ .Values.nats.kv_bucket_project_base.name }}
   replicas: {{ .Values.nats.kv_bucket_project_base.replicas }}
@@ -31,6 +33,8 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
 spec:
   bucket: {{ .Values.nats.kv_bucket_project_settings.name }}
   replicas: {{ .Values.nats.kv_bucket_project_settings.replicas }}


### PR DESCRIPTION
For the `keyvalues` CRD to populate in backstage, the kv buckets must be labeled. We'll use this data to check replica counts