### PR TITLE
feat: exclude health endpoints from tracing

### DIFF
--- a/cmd/project-api/main.go
+++ b/cmd/project-api/main.go
@@ -234,7 +234,12 @@ func setupHTTPServer(flags flags, svc *ProjectsAPI, gracefulCloseWG *sync.WaitGr
 	handler = middleware.RequestIDMiddleware()(handler)
 	handler = middleware.AuthorizationMiddleware()(handler)
 	// Wrap the handler with OpenTelemetry instrumentation
-	handler = otelhttp.NewHandler(handler, "project-service")
+	handler = otelhttp.NewHandler(handler, "project-service",
+		otelhttp.WithFilter(func(r *http.Request) bool {
+			p := r.URL.Path
+			return p != "/healthz" && p != "/livez" && p != "/readyz"
+		}),
+	)
 
 	// Set up http listener in a goroutine using provided command line parameters.
 	var addr string


### PR DESCRIPTION
## Summary

- Add `otelhttp.WithFilter` to `otelhttp.NewHandler` to skip span creation for `/healthz`, `/livez`, and `/readyz` Kubernetes probe endpoints
- Reduces high-volume, low-value trace noise from liveness/readiness probes

## Test plan

- [x] `go build ./...` passes

Issue: LFXV2-1583

🤖 Generated with [Claude Code](https://claude.com/claude-code)