### PR TITLE
[LFXV2-1608] docs: remove enricher system reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This service indexes project data into the indexer service, making it searchable
 - `lfx.index.project`: Published when a project is created, updated, or deleted. Contains the project base data and tags for indexing.
 - `lfx.index.project_settings`: Published when project settings are created or updated. Contains the project settings data and tags for indexing.
 
-Each indexer message includes an `IndexingConfig` that provides pre-computed metadata for the indexer service. When present, it bypasses server-side enrichers and controls how the document is stored, searched, and access-checked in the index. For the full field reference and message format details, see the [indexer service client guide](https://github.com/linuxfoundation/lfx-v2-indexer-service/blob/main/docs/client-guide.md).
+Create and update indexer messages include an `IndexingConfig` that provides the metadata controlling how the document is stored, searched, and access-checked in the index. Delete messages omit `IndexingConfig` — only the object ID is needed to remove the document. For the full field reference and message format details, see the [indexer service client guide](https://github.com/linuxfoundation/lfx-v2-indexer-service/blob/main/docs/client-guide.md).
 
 For the data schemas, tags, access control values, parent references, and fulltext fields for all resource types — see [`docs/indexer-contract.md`](docs/indexer-contract.md).
 


### PR DESCRIPTION
## Summary

- Replace stale "bypasses server-side enrichers" wording in the Indexer Contract section of `README.md`
- Aligns with the actual design: create/update messages supply `IndexingConfig`; delete messages omit it

## Ticket

[LFXV2-1608](https://jira.linuxfoundation.org/browse/LFXV2-1608)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1608]: https://linuxfoundation.atlassian.net/browse/LFXV2-1608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ