### PR TITLE
[LFXV2-1610] fix(helm): use Release.Namespace instead of hardcoded lfx for NATS stores

### DIFF
--- a/charts/lfx-v2-project-service/templates/nats-kv-buckets.yaml
+++ b/charts/lfx-v2-project-service/templates/nats-kv-buckets.yaml
@@ -6,7 +6,7 @@ apiVersion: jetstream.nats.io/v1beta2
 kind: KeyValue
 metadata:
   name: {{ .Values.nats.kv_bucket_project_base.name }}
-  namespace: lfx
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.nats.kv_bucket_project_base.keep }}
   annotations:
     "helm.sh/resource-policy": keep
@@ -28,7 +28,7 @@ apiVersion: jetstream.nats.io/v1beta2
 kind: KeyValue
 metadata:
   name: {{ .Values.nats.kv_bucket_project_settings.name }}
-  namespace: lfx
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.nats.kv_bucket_project_settings.keep }}
   annotations:
     "helm.sh/resource-policy": keep
@@ -50,7 +50,7 @@ apiVersion: jetstream.nats.io/v1beta2
 kind: KeyValue
 metadata:
   name: {{ .Values.nats.kv_bucket_project_links.name }}
-  namespace: lfx
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.nats.kv_bucket_project_links.keep }}
   annotations:
     "helm.sh/resource-policy": keep
@@ -72,7 +72,7 @@ apiVersion: jetstream.nats.io/v1beta2
 kind: KeyValue
 metadata:
   name: {{ .Values.nats.kv_bucket_project_folders.name }}
-  namespace: lfx
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.nats.kv_bucket_project_folders.keep }}
   annotations:
     "helm.sh/resource-policy": keep
@@ -94,7 +94,7 @@ apiVersion: jetstream.nats.io/v1beta2
 kind: KeyValue
 metadata:
   name: {{ .Values.nats.kv_bucket_project_documents.name }}
-  namespace: lfx
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.nats.kv_bucket_project_documents.keep }}
   annotations:
     "helm.sh/resource-policy": keep

--- a/charts/lfx-v2-project-service/templates/nats-object-stores.yaml
+++ b/charts/lfx-v2-project-service/templates/nats-object-stores.yaml
@@ -6,7 +6,7 @@ apiVersion: jetstream.nats.io/v1beta2
 kind: ObjectStore
 metadata:
   name: {{ .Values.nats.object_store_project_documents.name }}
-  namespace: lfx
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.nats.object_store_project_documents.keep }}
   annotations:
     "helm.sh/resource-policy": keep


### PR DESCRIPTION
## Summary

- All NATS `KeyValue` and `ObjectStore` Helm templates were hardcoded to `namespace: lfx`, causing them to be created in the wrong namespace when the service is deployed to its own `project-service` namespace
- Replaced all 6 occurrences with `{{ .Release.Namespace }}` to align with how the committee service handles this
- Fixes the `nats: bucket not found` error when starting the service in environments where the NATS operator scopes resources by namespace

## Ticket

[LFXV2-1610](https://linuxfoundation.atlassian.net/browse/LFXV2-1610)

## Migration Note

When upgrading existing deployments, manually delete the old CRDs from the `lfx` namespace before upgrading — the NATS data itself is safe as bucket names are cluster-scoped within NATS:

```bash
kubectl delete keyvalue -n lfx projects project-settings project-links project-folders project-documents-metadata
kubectl delete objectstore -n lfx project-documents
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1610]: https://linuxfoundation.atlassian.net/browse/LFXV2-1610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ