### PR TITLE
[LFXV2-1701] fix: move startup log config message after handler initialization

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -92,11 +92,6 @@ func InitStructureLogConfig() slog.Handler {
 		f()
 	}
 
-	slog.Info("log config",
-		"logLevel", logOptions.Level,
-		"addSource", logOptions.AddSource,
-	)
-
 	h = slog.NewJSONHandler(os.Stdout, logOptions)
 	log.SetFlags(log.Llongfile)
 
@@ -106,6 +101,11 @@ func InitStructureLogConfig() slog.Handler {
 	// Wrap with contextHandler to support context-based attributes
 	logger := contextHandler{otelHandler}
 	slog.SetDefault(slog.New(logger))
+
+	slog.Info("log config",
+		"logLevel", logOptions.Level,
+		"addSource", logOptions.AddSource,
+	)
 
 	return logger
 }


### PR DESCRIPTION
## Summary

- Moves the `slog.Info("log config", ...)` call to after `slog.SetDefault` is invoked in `InitStructureLogConfig`
- Before this fix, the log fired using the default slog handler which writes to **stderr**; Datadog interprets stderr output as error-level regardless of the slog level in code
- After this fix, the log uses the configured JSON handler writing to stdout and is correctly classified as INFO in Datadog

## Ticket

[LFXV2-1701](https://jira.linuxfoundation.org/browse/LFXV2-1701)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1701]: https://linuxfoundation.atlassian.net/browse/LFXV2-1701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ