### PR TITLE
[LFXV2-1730] fix: email button color, project URL, and body text

### DIFF
--- a/internal/service/email/templates/project_role_notification.html
+++ b/internal/service/email/templates/project_role_notification.html
@@ -41,7 +41,7 @@
     <p>{{.InviterName}} has added you as a <strong>{{.Role}}</strong> on the <strong>{{.ProjectName}}</strong> project in LFX Self-Serve.</p>
     <p>You can view the project dashboard by visiting the link below.</p>
 
-    <a href="{{.ProjectURL}}" class="btn" style="color:#ffffff!important;">View Project</a>
+    <!-- djlint:off H021 --><a href="{{.ProjectURL}}" class="btn" style="color:#ffffff!important;">View Project</a><!-- djlint:on H021 -->
     <p class="btn-note">If the button above doesn't work, paste this into your browser: <a href="{{.ProjectURL}}">{{.ProjectURL}}</a></p>
 
     <p class="signoff">Thank you,<br><strong>The Linux Foundation Team</strong></p>

--- a/internal/service/email/templates/project_role_notification.html
+++ b/internal/service/email/templates/project_role_notification.html
@@ -16,7 +16,7 @@
         hr { border: none; border-top: 1px solid #e5e7eb; margin: 0 0 32px 0; }
         p { font-size: 16px; color: #374151; line-height: 1.6; margin: 0 0 16px 0; }
         .greeting { font-size: 15px; color: #374151; margin: 0 0 8px 0; }
-        .btn { display: inline-block; background-color: #009AFF; color: #ffffff; text-decoration: none; font-size: 15px; font-weight: 600; padding: 12px 24px; border-radius: 8px; margin-bottom: 12px; }
+        .btn { display: inline-block; background-color: #009AFF; color: #ffffff !important; text-decoration: none; font-size: 15px; font-weight: 600; padding: 12px 24px; border-radius: 8px; margin-bottom: 12px; }
         .btn-note { font-size: 13px; color: #6b7280; margin: 0 0 28px 0; }
         .btn-note a { color: #009AFF; text-decoration: none; }
         .signoff { font-size: 15px; color: #374151; margin: 0 0 32px 0; line-height: 1.7; }
@@ -41,7 +41,7 @@
     <p>{{.InviterName}} has added you as a <strong>{{.Role}}</strong> on the <strong>{{.ProjectName}}</strong> project in LFX Self-Serve.</p>
     <p>You can view the project and manage your responsibilities by visiting the link below.</p>
 
-    <a href="{{.ProjectURL}}" class="btn">View Project</a>
+    <a href="{{.ProjectURL}}" class="btn" style="color:#ffffff!important;">View Project</a>
     <p class="btn-note">If the button above doesn't work, paste this into your browser: <a href="{{.ProjectURL}}">{{.ProjectURL}}</a></p>
 
     <p class="signoff">Thank you,<br><strong>The Linux Foundation Team</strong></p>

--- a/internal/service/email/templates/project_role_notification.html
+++ b/internal/service/email/templates/project_role_notification.html
@@ -39,7 +39,7 @@
     <p class="greeting">Hi {{.RecipientName}},</p>
 
     <p>{{.InviterName}} has added you as a <strong>{{.Role}}</strong> on the <strong>{{.ProjectName}}</strong> project in LFX Self-Serve.</p>
-    <p>You can view the project and manage your responsibilities by visiting the link below.</p>
+    <p>You can view the project dashboard by visiting the link below.</p>
 
     <a href="{{.ProjectURL}}" class="btn" style="color:#ffffff!important;">View Project</a>
     <p class="btn-note">If the button above doesn't work, paste this into your browser: <a href="{{.ProjectURL}}">{{.ProjectURL}}</a></p>

--- a/internal/service/project_subscriber.go
+++ b/internal/service/project_subscriber.go
@@ -43,7 +43,11 @@ func (s *ProjectsService) HandleProjectSettingsUpdated(ctx context.Context, msg 
 		return nil
 	}
 
-	projectURL := strings.TrimRight(s.Config.LFXSelfServeBaseURL, "/") + "/projects/overview"
+	baseURL := strings.TrimRight(s.Config.LFXSelfServeBaseURL, "/") + "/projects/overview"
+	projectURL := baseURL
+	if projectBase.Slug != "" {
+		projectURL = baseURL + "?project=" + projectBase.Slug
+	}
 
 	inviterName := s.resolveActorDisplayName(ctx, event.Actor)
 

--- a/internal/service/project_subscriber_test.go
+++ b/internal/service/project_subscriber_test.go
@@ -6,6 +6,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	emailapi "github.com/linuxfoundation/lfx-v2-email-service/pkg/api"
@@ -34,12 +35,14 @@ func TestHandleProjectSettingsUpdated(t *testing.T) {
 	bob := events.UserInfo{Username: "bob", Email: "bob@example.com", Name: "Bob"}
 
 	tests := []struct {
-		name           string
-		event          events.ProjectSettingsUpdatedMessage
-		projectBase    *models.ProjectBase
-		projectBaseErr error
-		wantSendCount  int
-		msgBuilderErr  error
+		name              string
+		event             events.ProjectSettingsUpdatedMessage
+		projectBase       *models.ProjectBase
+		projectBaseErr    error
+		wantSendCount     int
+		msgBuilderErr     error
+		wantURLContains   string // assert HTML body contains this substring
+		wantURLNotContain string // assert HTML body does NOT contain this substring
 	}{
 		{
 			name: "no additions — no emails sent",
@@ -110,6 +113,31 @@ func TestHandleProjectSettingsUpdated(t *testing.T) {
 			projectBaseErr: assert.AnError,
 			wantSendCount:  0,
 		},
+		{
+			name: "project with slug — URL includes slug query param",
+			event: events.ProjectSettingsUpdatedMessage{
+				ProjectUID:  "proj-1",
+				OldSettings: events.ProjectSettings{},
+				NewSettings: events.ProjectSettings{Writers: []events.UserInfo{alice}},
+				Actor:       events.Actor{Name: "Admin"},
+			},
+			projectBase:     makeProjectBase("proj-1", "Demo", "my-project"),
+			wantSendCount:   1,
+			wantURLContains: "?project=my-project",
+		},
+		{
+			name: "project without slug — fallback URL has no query param",
+			event: events.ProjectSettingsUpdatedMessage{
+				ProjectUID:  "proj-1",
+				OldSettings: events.ProjectSettings{},
+				NewSettings: events.ProjectSettings{Writers: []events.UserInfo{alice}},
+				Actor:       events.Actor{Name: "Admin"},
+			},
+			projectBase:       makeProjectBase("proj-1", "Demo", ""),
+			wantSendCount:     1,
+			wantURLContains:   "projects/overview",
+			wantURLNotContain: "?project=",
+		},
 	}
 
 	for _, tt := range tests {
@@ -123,8 +151,22 @@ func TestHandleProjectSettingsUpdated(t *testing.T) {
 			}
 
 			if tt.wantSendCount > 0 {
-				mockMsg.On("SendEmailRequest", mock.Anything, mock.AnythingOfType("api.SendEmailRequest")).
-					Return(tt.msgBuilderErr).Times(tt.wantSendCount)
+				if tt.wantURLContains != "" || tt.wantURLNotContain != "" {
+					wantContains := tt.wantURLContains
+					wantNotContain := tt.wantURLNotContain
+					mockMsg.On("SendEmailRequest", mock.Anything, mock.MatchedBy(func(req emailapi.SendEmailRequest) bool {
+						if wantContains != "" && !strings.Contains(req.HTML, wantContains) {
+							return false
+						}
+						if wantNotContain != "" && strings.Contains(req.HTML, wantNotContain) {
+							return false
+						}
+						return true
+					})).Return(tt.msgBuilderErr).Times(tt.wantSendCount)
+				} else {
+					mockMsg.On("SendEmailRequest", mock.Anything, mock.AnythingOfType("api.SendEmailRequest")).
+						Return(tt.msgBuilderErr).Times(tt.wantSendCount)
+				}
 			}
 
 			svc := &ProjectsService{


### PR DESCRIPTION
## Summary

- Add `!important` to `.btn` CSS color and inline `style="color:#ffffff!important;"` on the anchor tag so Gmail renders the button text white instead of the default link blue
- Append `?project=<slug>` to the View Project button URL so the link navigates directly to the specific project page
- Update email body copy from "view the project and manage your responsibilities" to "view the project dashboard"

## Ticket

[LFXV2-1730](https://linuxfoundation.atlassian.net/browse/LFXV2-1730)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1730]: https://linuxfoundation.atlassian.net/browse/LFXV2-1730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ