### PR TITLE
[LFXV2-1730] fix: correct LFX Self-Serve base URLs for all environments

### DIFF
--- a/cmd/project-api/main.go
+++ b/cmd/project-api/main.go
@@ -184,9 +184,9 @@ func parseEnv() environment {
 		case "prod":
 			lfxSelfServeBaseURL = "https://app.lfx.dev"
 		case "staging", "stg":
-			lfxSelfServeBaseURL = "https://staging.app.lfx.dev"
+			lfxSelfServeBaseURL = "https://app.staging.lfx.dev"
 		default:
-			lfxSelfServeBaseURL = "https://dev.app.lfx.dev"
+			lfxSelfServeBaseURL = "https://app.dev.lfx.dev"
 		}
 	}
 	return environment{

--- a/internal/service/email/project_role_notification_test.go
+++ b/internal/service/email/project_role_notification_test.go
@@ -16,7 +16,7 @@ func TestRenderProjectRoleNotification(t *testing.T) {
 		RecipientName: "Alice",
 		ProjectName:   "Demo Project",
 		Role:          "Writer",
-		ProjectURL:    "https://dev.app.lfx.dev/projects/demo-project",
+		ProjectURL:    "https://app.dev.lfx.dev/projects/demo-project",
 		InviterName:   "Bob",
 	}
 
@@ -30,14 +30,14 @@ func TestRenderProjectRoleNotification(t *testing.T) {
 	assert.Contains(t, html, "Alice")
 	assert.Contains(t, html, "Demo Project")
 	assert.Contains(t, html, "Writer")
-	assert.Contains(t, html, "https://dev.app.lfx.dev/projects/demo-project")
+	assert.Contains(t, html, "https://app.dev.lfx.dev/projects/demo-project")
 	assert.Contains(t, html, "Bob")
 	assert.True(t, strings.Contains(html, "<html"), "expected HTML output")
 
 	assert.Contains(t, text, "Alice")
 	assert.Contains(t, text, "Demo Project")
 	assert.Contains(t, text, "Writer")
-	assert.Contains(t, text, "https://dev.app.lfx.dev/projects/demo-project")
+	assert.Contains(t, text, "https://app.dev.lfx.dev/projects/demo-project")
 	assert.Contains(t, text, "Bob")
 	assert.False(t, strings.Contains(text, "<html"), "expected plain text output")
 }

--- a/internal/service/project_subscriber_test.go
+++ b/internal/service/project_subscriber_test.go
@@ -173,7 +173,7 @@ func TestHandleProjectSettingsUpdated(t *testing.T) {
 				ProjectRepository: mockRepo,
 				MessageBuilder:    mockMsg,
 				Config: ServiceConfig{
-					LFXSelfServeBaseURL: "https://dev.app.lfx.dev",
+					LFXSelfServeBaseURL: "https://app.dev.lfx.dev",
 				},
 			}
 


### PR DESCRIPTION
## Summary

- Corrected staging base URL from `staging.app.lfx.dev` → `app.staging.lfx.dev`
- Corrected dev base URL from `dev.app.lfx.dev` → `app.dev.lfx.dev`
- Prod URL (`app.lfx.dev`) was already correct — no change
- Updated test fixtures to use the corrected dev URL for consistency

## Ticket

[LFXV2-1730](https://linuxfoundation.atlassian.net/browse/LFXV2-1730)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1730]: https://linuxfoundation.atlassian.net/browse/LFXV2-1730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ