### PR TITLE
[LFXV2-1730] fix: correct project URL path from /projects/overview to /project/overview

### DIFF
--- a/internal/service/project_subscriber.go
+++ b/internal/service/project_subscriber.go
@@ -43,7 +43,7 @@ func (s *ProjectsService) HandleProjectSettingsUpdated(ctx context.Context, msg 
 		return nil
 	}
 
-	baseURL := strings.TrimRight(s.Config.LFXSelfServeBaseURL, "/") + "/projects/overview"
+	baseURL := strings.TrimRight(s.Config.LFXSelfServeBaseURL, "/") + "/project/overview"
 	projectURL := baseURL
 	if projectBase.Slug != "" {
 		projectURL = baseURL + "?project=" + projectBase.Slug

--- a/internal/service/project_subscriber_test.go
+++ b/internal/service/project_subscriber_test.go
@@ -135,7 +135,7 @@ func TestHandleProjectSettingsUpdated(t *testing.T) {
 			},
 			projectBase:       makeProjectBase("proj-1", "Demo", ""),
 			wantSendCount:     1,
-			wantURLContains:   "projects/overview",
+			wantURLContains:   "project/overview",
 			wantURLNotContain: "?project=",
 		},
 	}


### PR DESCRIPTION
## Summary

- Fixed notification email link path from `/projects/overview` (plural) to `/project/overview` (singular) to match the correct app route
- Updated test assertion to match the corrected path

## Ticket

[LFXV2-1730](https://linuxfoundation.atlassian.net/browse/LFXV2-1730)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1730]: https://linuxfoundation.atlassian.net/browse/LFXV2-1730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ