### PR TITLE
[LFXV2-1961] Enrich UserInfo username from email lookup on project settings and create

### DIFF
--- a/cmd/project-api/service_endpoint_project_test.go
+++ b/cmd/project-api/service_endpoint_project_test.go
@@ -178,12 +178,6 @@ func TestCreateProject(t *testing.T) {
 				Description: "Test description",
 				Public:      misc.BoolPtr(true),
 				ParentUID:   "787620d0-d7de-449a-b0bf-9d28b13da818",
-				Auditors: []*projsvc.UserInfo{
-					{Username: misc.StringPtr("user1"), Name: misc.StringPtr("User One"), Email: misc.StringPtr("user1@example.com"), Avatar: misc.StringPtr("")},
-				},
-				Writers: []*projsvc.UserInfo{
-					{Username: misc.StringPtr("user2"), Name: misc.StringPtr("User Two"), Email: misc.StringPtr("user2@example.com"), Avatar: misc.StringPtr("")},
-				},
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockMsg *domain.MockMessageBuilder) {
 				// Mock slug exists

--- a/cmd/project-api/service_endpoint_project_test.go
+++ b/cmd/project-api/service_endpoint_project_test.go
@@ -162,8 +162,12 @@ func TestCreateProject(t *testing.T) {
 				mockRepo.On("ProjectExists", mock.Anything, "787620d0-d7de-449a-b0bf-9d28b13da818").Return(true, nil)
 				// Mock slug doesn't exist
 				mockRepo.On("ProjectSlugExists", mock.Anything, "test-project").Return(false, nil)
-				// Mock successful project creation
-				mockRepo.On("CreateProject", mock.Anything, mock.AnythingOfType("*models.ProjectBase"), mock.AnythingOfType("*models.ProjectSettings")).Return(nil)
+				// Mock successful project creation — MatchedBy validates enriched LFIDs were persisted.
+				mockRepo.On("CreateProject", mock.Anything, mock.AnythingOfType("*models.ProjectBase"),
+					mock.MatchedBy(func(s *models.ProjectSettings) bool {
+						return len(s.Writers) == 2 && s.Writers[0].Username == "user1" && s.Writers[1].Username == "user2" &&
+							len(s.Auditors) == 2 && s.Auditors[0].Username == "user3" && s.Auditors[1].Username == "user4"
+					})).Return(nil)
 				// Mock message sending
 				mockMsg.On("SendIndexerMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.IndexerMessageEnvelope"), mock.AnythingOfType("bool")).Return(nil).Times(2)
 				mockMsg.On("SendAccessMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.GenericFGAMessage"), mock.AnythingOfType("bool")).Return(nil)

--- a/cmd/project-api/service_endpoint_project_test.go
+++ b/cmd/project-api/service_endpoint_project_test.go
@@ -190,8 +190,9 @@ func TestCreateProject(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			api, mockRepo, mockMsg := setupAPI()
+			mockUserReader := api.service.UserReader.(*domain.MockUserReader)
 			if tt.setupUserReader != nil {
-				tt.setupUserReader(api.service.UserReader.(*domain.MockUserReader))
+				tt.setupUserReader(mockUserReader)
 			}
 			tt.setupMocks(mockRepo, mockMsg)
 
@@ -208,6 +209,7 @@ func TestCreateProject(t *testing.T) {
 
 			mockRepo.AssertExpectations(t)
 			mockMsg.AssertExpectations(t)
+			mockUserReader.AssertExpectations(t)
 		})
 	}
 }

--- a/cmd/project-api/service_endpoint_project_test.go
+++ b/cmd/project-api/service_endpoint_project_test.go
@@ -30,6 +30,7 @@ func setupAPI() (*ProjectsAPI, *domain.MockProjectRepository, *domain.MockMessag
 	mockRepo := &domain.MockProjectRepository{}
 	mockMessageBuilder := &domain.MockMessageBuilder{}
 	mockJwtAuth := &auth.MockJWTAuth{}
+	mockUserReader := &domain.MockUserReader{}
 
 	projectService := &service.ProjectsService{
 		ProjectRepository:  mockRepo,
@@ -38,6 +39,7 @@ func setupAPI() (*ProjectsAPI, *domain.MockProjectRepository, *domain.MockMessag
 		FolderRepository:   &domain.MockFolderRepository{},
 		MessageBuilder:     mockMessageBuilder,
 		Auth:               mockJwtAuth,
+		UserReader:         mockUserReader,
 	}
 
 	api := &ProjectsAPI{
@@ -126,10 +128,11 @@ func TestGetProjects(t *testing.T) {
 
 func TestCreateProject(t *testing.T) {
 	tests := []struct {
-		name          string
-		payload       *projsvc.CreateProjectPayload
-		setupMocks    func(*domain.MockProjectRepository, *domain.MockMessageBuilder)
-		expectedError bool
+		name            string
+		payload         *projsvc.CreateProjectPayload
+		setupMocks      func(*domain.MockProjectRepository, *domain.MockMessageBuilder)
+		setupUserReader func(*domain.MockUserReader)
+		expectedError   bool
 	}{
 		{
 			name: "success",
@@ -147,6 +150,12 @@ func TestCreateProject(t *testing.T) {
 					{Username: misc.StringPtr("user3"), Name: misc.StringPtr("User Three"), Email: misc.StringPtr("user3@example.com"), Avatar: misc.StringPtr("")},
 					{Username: misc.StringPtr("user4"), Name: misc.StringPtr("User Four"), Email: misc.StringPtr("user4@example.com"), Avatar: misc.StringPtr("")},
 				},
+			},
+			setupUserReader: func(mockUserReader *domain.MockUserReader) {
+				mockUserReader.On("UsernameByEmail", mock.Anything, "user1@example.com").Return("user1", nil)
+				mockUserReader.On("UsernameByEmail", mock.Anything, "user2@example.com").Return("user2", nil)
+				mockUserReader.On("UsernameByEmail", mock.Anything, "user3@example.com").Return("user3", nil)
+				mockUserReader.On("UsernameByEmail", mock.Anything, "user4@example.com").Return("user4", nil)
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockMsg *domain.MockMessageBuilder) {
 				// Mock parent project exists (for ParentUID validation)
@@ -187,6 +196,9 @@ func TestCreateProject(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			api, mockRepo, mockMsg := setupAPI()
+			if tt.setupUserReader != nil {
+				tt.setupUserReader(api.service.UserReader.(*domain.MockUserReader))
+			}
 			tt.setupMocks(mockRepo, mockMsg)
 
 			result, err := api.CreateProject(context.Background(), tt.payload)

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -50,5 +50,6 @@ var (
 	ErrInviteMappingNotFound = errors.New("invite mapping not found")
 
 	// ErrUserNotFound is returned by UserReader when no registered user matches the given lookup criteria.
+	// It is handled internally (treated as a lookup miss) and is never surfaced to the HTTP layer.
 	ErrUserNotFound = errors.New("user not found")
 )

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -48,4 +48,7 @@ var (
 	// ErrInviteMappingNotFound is returned when no invite→project mapping exists for the given invite UID.
 	// This is distinct from ErrProjectNotFound: the project may exist but no mapping was written for this invite.
 	ErrInviteMappingNotFound = errors.New("invite mapping not found")
+
+	// ErrUserNotFound is returned by UserReader when no registered user matches the given lookup criteria.
+	ErrUserNotFound = errors.New("user not found")
 )

--- a/internal/domain/mock.go
+++ b/internal/domain/mock.go
@@ -280,6 +280,24 @@ func (m *MockMessageBuilder) SendInviteRequest(ctx context.Context, req inviteap
 	return args.Get(0).(InviteResult), args.Error(1)
 }
 
+// MockUserReader implements UserReader for testing.
+type MockUserReader struct {
+	mock.Mock
+}
+
+func (m *MockUserReader) UserMetadataByPrincipal(ctx context.Context, principal string) (*UserMetadata, error) {
+	args := m.Called(ctx, principal)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*UserMetadata), args.Error(1)
+}
+
+func (m *MockUserReader) UsernameByEmail(ctx context.Context, email string) (string, error) {
+	args := m.Called(ctx, email)
+	return args.String(0), args.Error(1)
+}
+
 // MockMessage implements Message for testing
 type MockMessage struct {
 	mock.Mock

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -16,4 +16,7 @@ type UserMetadata struct {
 type UserReader interface {
 	// UserMetadataByPrincipal retrieves profile metadata for a user by their principal.
 	UserMetadataByPrincipal(ctx context.Context, principal string) (*UserMetadata, error)
+	// UsernameByEmail resolves the registered LFID username for the given primary email address.
+	// Returns ErrUserNotFound when no user is registered with that email.
+	UsernameByEmail(ctx context.Context, email string) (string, error)
 }

--- a/internal/infrastructure/nats/user_reader.go
+++ b/internal/infrastructure/nats/user_reader.go
@@ -83,10 +83,14 @@ func (u *UserReaderNATS) UsernameByEmail(ctx context.Context, email string) (str
 		return "", fmt.Errorf("email_to_username request failed: %w", err)
 	}
 
-	// Try to decode as a JSON error envelope first — the auth service sends this on miss.
-	var errResp emailToUsernameErrorResponse
-	if json.Unmarshal(reply.Data, &errResp) == nil && !errResp.Success {
-		return "", domain.ErrUserNotFound
+	// The auth service sends a plain-text username on success and a JSON error envelope on miss.
+	// Only attempt JSON decode when the body starts with '{' to avoid misinterpreting a valid
+	// plain-text username that happens to be valid JSON (e.g. a numeric string).
+	if len(reply.Data) > 0 && reply.Data[0] == '{' {
+		var errResp emailToUsernameErrorResponse
+		if json.Unmarshal(reply.Data, &errResp) == nil && !errResp.Success {
+			return "", domain.ErrUserNotFound
+		}
 	}
 
 	username := string(reply.Data)

--- a/internal/infrastructure/nats/user_reader.go
+++ b/internal/infrastructure/nats/user_reader.go
@@ -64,3 +64,35 @@ func (u *UserReaderNATS) UserMetadataByPrincipal(ctx context.Context, principal 
 	}
 	return result, nil
 }
+
+// emailToUsernameErrorResponse mirrors the auth-service error envelope for lfx.auth-service.email_to_username.
+// The type is internal to the auth service, so we keep a local copy of the relevant fields.
+type emailToUsernameErrorResponse struct {
+	Success bool   `json:"success"`
+	Error   string `json:"error,omitempty"`
+}
+
+// UsernameByEmail resolves the registered LFID username for the given primary email address.
+// The auth service replies with a plain-text username on success, or a JSON error envelope on miss.
+func (u *UserReaderNATS) UsernameByEmail(ctx context.Context, email string) (string, error) {
+	reply, err := u.NatsConn.RequestMsgWithContext(ctx, &natsgo.Msg{
+		Subject: constants.AuthEmailToUsernameSubject,
+		Data:    []byte(email),
+	})
+	if err != nil {
+		return "", fmt.Errorf("email_to_username request failed: %w", err)
+	}
+
+	// Try to decode as a JSON error envelope first — the auth service sends this on miss.
+	var errResp emailToUsernameErrorResponse
+	if json.Unmarshal(reply.Data, &errResp) == nil && !errResp.Success {
+		return "", domain.ErrUserNotFound
+	}
+
+	username := string(reply.Data)
+	if username == "" {
+		return "", domain.ErrUserNotFound
+	}
+
+	return username, nil
+}

--- a/internal/infrastructure/nats/user_reader.go
+++ b/internal/infrastructure/nats/user_reader.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	natsgo "github.com/nats-io/nats.go"
 
@@ -84,19 +85,21 @@ func (u *UserReaderNATS) UsernameByEmail(ctx context.Context, email string) (str
 	}
 
 	// The auth service sends a plain-text username on success and a JSON error envelope on miss.
-	// Only attempt JSON decode when the body starts with '{' to avoid misinterpreting a valid
-	// plain-text username that happens to be valid JSON (e.g. a numeric string).
-	if len(reply.Data) > 0 && reply.Data[0] == '{' {
+	// Trim leading/trailing whitespace before inspection so intermediaries that add a trailing
+	// newline or leading space don't corrupt the username or bypass JSON detection.
+	body := strings.TrimSpace(string(reply.Data))
+	if body == "" {
+		return "", domain.ErrUserNotFound
+	}
+
+	// Only attempt JSON decode when the trimmed body starts with '{' to avoid misinterpreting a
+	// valid plain-text username that happens to be valid JSON (e.g. a numeric string).
+	if body[0] == '{' {
 		var errResp emailToUsernameErrorResponse
-		if json.Unmarshal(reply.Data, &errResp) == nil && !errResp.Success {
+		if json.Unmarshal([]byte(body), &errResp) == nil && !errResp.Success {
 			return "", domain.ErrUserNotFound
 		}
 	}
 
-	username := string(reply.Data)
-	if username == "" {
-		return "", domain.ErrUserNotFound
-	}
-
-	return username, nil
+	return body, nil
 }

--- a/internal/service/converters.go
+++ b/internal/service/converters.go
@@ -537,15 +537,21 @@ func extractUsername(user *models.UserInfo) string {
 	return user.Username
 }
 
-// extractUsernames extracts usernames from UserInfo slice for access control
+// extractUsernames extracts non-empty usernames from UserInfo slice for access control.
+// Empty usernames (lookup miss / unregistered email) are excluded to prevent invalid FGA tuples.
 func extractUsernames(users []models.UserInfo) []string {
 	if len(users) == 0 {
 		return nil
 	}
 
-	usernames := make([]string, len(users))
-	for i, user := range users {
-		usernames[i] = user.Username
+	usernames := make([]string, 0, len(users))
+	for _, user := range users {
+		if user.Username != "" {
+			usernames = append(usernames, user.Username)
+		}
+	}
+	if len(usernames) == 0 {
+		return nil
 	}
 	return usernames
 }

--- a/internal/service/project_handlers_test.go
+++ b/internal/service/project_handlers_test.go
@@ -636,6 +636,7 @@ func TestProjectsService_MessageHandling_ErrorCases(t *testing.T) {
 					LinkRepository:     &domain.MockLinkRepository{},
 					FolderRepository:   &domain.MockFolderRepository{},
 					MessageBuilder:     &domain.MockMessageBuilder{},
+					UserReader:         &domain.MockUserReader{},
 					Auth:               &auth.MockJWTAuth{},
 				}
 			},

--- a/internal/service/project_operations.go
+++ b/internal/service/project_operations.go
@@ -107,6 +107,21 @@ func (s *ProjectsService) CreateProject(ctx context.Context, payload *projsvc.Cr
 		runSync = *payload.XSync
 	}
 
+	// Enrich writer/auditor/coordinator usernames from the auth service before persisting.
+	// The caller is not authoritative for another user's LFID — always use the lookup result.
+	for _, slice := range [][]*projsvc.UserInfo{payload.Writers, payload.Auditors, payload.MeetingCoordinators} {
+		if err := s.enrichUserSlice(ctx, slice); err != nil {
+			slog.ErrorContext(ctx, "error enriching user slice", constants.ErrKey, err)
+			return nil, domain.ErrInternal
+		}
+	}
+	for _, single := range []*projsvc.UserInfo{payload.ExecutiveDirector, payload.ProgramManager, payload.OpportunityOwner} {
+		if err := s.enrichSingleUser(ctx, single); err != nil {
+			slog.ErrorContext(ctx, "error enriching single user", constants.ErrKey, err)
+			return nil, domain.ErrInternal
+		}
+	}
+
 	// Create the project and settings structs
 	id := uuid.NewString()
 	project := &projsvc.ProjectBase{
@@ -525,6 +540,20 @@ func (s *ProjectsService) UpdateProjectSettings(ctx context.Context, payload *pr
 		runSync = *payload.XSync
 	}
 
+	// Enrich writer/auditor/coordinator usernames from the auth service before persisting.
+	for _, slice := range [][]*projsvc.UserInfo{payload.Writers, payload.Auditors, payload.MeetingCoordinators} {
+		if err := s.enrichUserSlice(ctx, slice); err != nil {
+			slog.ErrorContext(ctx, "error enriching user slice", constants.ErrKey, err)
+			return nil, domain.ErrInternal
+		}
+	}
+	for _, single := range []*projsvc.UserInfo{payload.ExecutiveDirector, payload.ProgramManager, payload.OpportunityOwner} {
+		if err := s.enrichSingleUser(ctx, single); err != nil {
+			slog.ErrorContext(ctx, "error enriching single user", constants.ErrKey, err)
+			return nil, domain.ErrInternal
+		}
+	}
+
 	// Prepare the updated project settings
 	currentTime := time.Now().UTC()
 	projectSettings := &projsvc.ProjectSettings{
@@ -722,4 +751,40 @@ func (s *ProjectsService) DeleteProject(ctx context.Context, payload *projsvc.De
 // This matches v1's strict validation where Type must equal "Crowdfunding" (not in combination with other types).
 func isCrowdfundingOnly(fundingModels []string) bool {
 	return len(fundingModels) == 1 && fundingModels[0] == "Crowdfunding"
+}
+
+// enrichUserSlice overwrites the Username field on each UserInfo entry with the authoritative LFID
+// returned by the auth service for that entry's email address.
+// The caller's supplied username is always replaced — it is untrusted because the caller does not
+// own the assignee's login profile.
+// If the email is missing or does not match a registered user the username is cleared to nil.
+// Any transport error from the auth service is returned and the calling request fails.
+func (s *ProjectsService) enrichUserSlice(ctx context.Context, users []*projsvc.UserInfo) error {
+	for _, u := range users {
+		if err := s.enrichSingleUser(ctx, u); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// enrichSingleUser enriches one UserInfo entry in place; see enrichUserSlice for full semantics.
+func (s *ProjectsService) enrichSingleUser(ctx context.Context, u *projsvc.UserInfo) error {
+	if u == nil {
+		return nil
+	}
+	if u.Email == nil || *u.Email == "" {
+		u.Username = nil
+		return nil
+	}
+	username, err := s.UserReader.UsernameByEmail(ctx, *u.Email)
+	if err != nil {
+		if errors.Is(err, domain.ErrUserNotFound) {
+			u.Username = nil
+			return nil
+		}
+		return err
+	}
+	u.Username = &username
+	return nil
 }

--- a/internal/service/project_operations.go
+++ b/internal/service/project_operations.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"log/slog"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -22,8 +24,6 @@ import (
 	"github.com/linuxfoundation/lfx-v2-project-service/pkg/constants"
 	"github.com/linuxfoundation/lfx-v2-project-service/pkg/events"
 	"github.com/linuxfoundation/lfx-v2-project-service/pkg/misc"
-	"sync"
-
 	"golang.org/x/sync/errgroup"
 )
 
@@ -771,10 +771,12 @@ func (s *ProjectsService) enrichAllRoleFields(
 			u.Username = misc.StringPtr("")
 			return
 		}
-		eg := byEmail[*u.Email]
+		// Normalize email so Bob@Example.com and bob@example.com share the same lookup.
+		normEmail := strings.ToLower(strings.TrimSpace(*u.Email))
+		eg := byEmail[normEmail]
 		if eg == nil {
 			eg = &group{}
-			byEmail[*u.Email] = eg
+			byEmail[normEmail] = eg
 		}
 		eg.users = append(eg.users, u)
 	}

--- a/internal/service/project_operations.go
+++ b/internal/service/project_operations.go
@@ -22,6 +22,8 @@ import (
 	"github.com/linuxfoundation/lfx-v2-project-service/pkg/constants"
 	"github.com/linuxfoundation/lfx-v2-project-service/pkg/events"
 	"github.com/linuxfoundation/lfx-v2-project-service/pkg/misc"
+	"sync"
+
 	"golang.org/x/sync/errgroup"
 )
 
@@ -107,19 +109,13 @@ func (s *ProjectsService) CreateProject(ctx context.Context, payload *projsvc.Cr
 		runSync = *payload.XSync
 	}
 
-	// Enrich writer/auditor/coordinator usernames from the auth service before persisting.
-	// The caller is not authoritative for another user's LFID — always use the lookup result.
-	for _, slice := range [][]*projsvc.UserInfo{payload.Writers, payload.Auditors, payload.MeetingCoordinators} {
-		if err := s.enrichUserSlice(ctx, slice); err != nil {
-			slog.ErrorContext(ctx, "error enriching user slice", constants.ErrKey, err)
-			return nil, domain.ErrInternal
-		}
-	}
-	for _, single := range []*projsvc.UserInfo{payload.ExecutiveDirector, payload.ProgramManager, payload.OpportunityOwner} {
-		if err := s.enrichSingleUser(ctx, single); err != nil {
-			slog.ErrorContext(ctx, "error enriching single user", constants.ErrKey, err)
-			return nil, domain.ErrInternal
-		}
+	// Enrich usernames from the auth service before persisting; caller-supplied LFIDs are untrusted.
+	if err := s.enrichAllRoleFields(ctx,
+		[][]*projsvc.UserInfo{payload.Writers, payload.Auditors, payload.MeetingCoordinators},
+		[]*projsvc.UserInfo{payload.ExecutiveDirector, payload.ProgramManager, payload.OpportunityOwner},
+	); err != nil {
+		slog.ErrorContext(ctx, "error enriching user role fields", constants.ErrKey, err)
+		return nil, domain.ErrInternal
 	}
 
 	// Create the project and settings structs
@@ -540,18 +536,13 @@ func (s *ProjectsService) UpdateProjectSettings(ctx context.Context, payload *pr
 		runSync = *payload.XSync
 	}
 
-	// Enrich writer/auditor/coordinator usernames from the auth service before persisting.
-	for _, slice := range [][]*projsvc.UserInfo{payload.Writers, payload.Auditors, payload.MeetingCoordinators} {
-		if err := s.enrichUserSlice(ctx, slice); err != nil {
-			slog.ErrorContext(ctx, "error enriching user slice", constants.ErrKey, err)
-			return nil, domain.ErrInternal
-		}
-	}
-	for _, single := range []*projsvc.UserInfo{payload.ExecutiveDirector, payload.ProgramManager, payload.OpportunityOwner} {
-		if err := s.enrichSingleUser(ctx, single); err != nil {
-			slog.ErrorContext(ctx, "error enriching single user", constants.ErrKey, err)
-			return nil, domain.ErrInternal
-		}
+	// Enrich usernames from the auth service before persisting; caller-supplied LFIDs are untrusted.
+	if err := s.enrichAllRoleFields(ctx,
+		[][]*projsvc.UserInfo{payload.Writers, payload.Auditors, payload.MeetingCoordinators},
+		[]*projsvc.UserInfo{payload.ExecutiveDirector, payload.ProgramManager, payload.OpportunityOwner},
+	); err != nil {
+		slog.ErrorContext(ctx, "error enriching user role fields", constants.ErrKey, err)
+		return nil, domain.ErrInternal
 	}
 
 	// Prepare the updated project settings
@@ -753,47 +744,93 @@ func isCrowdfundingOnly(fundingModels []string) bool {
 	return len(fundingModels) == 1 && fundingModels[0] == "Crowdfunding"
 }
 
-// enrichUserSlice overwrites the Username field on each UserInfo entry with the authoritative LFID
-// returned by the auth service for that entry's email address.
-// The caller's supplied username is always replaced — it is untrusted because the caller does not
-// own the assignee's login profile.
-// If the email is missing or does not match a registered user the username is cleared to nil.
-// Any transport error from the auth service is returned and the calling request fails.
-func (s *ProjectsService) enrichUserSlice(ctx context.Context, users []*projsvc.UserInfo) error {
-	if len(users) == 0 {
+// enrichAllRoleFields overwrites Username on every UserInfo across all supplied slices and singles
+// with the authoritative LFID from the auth service.
+// Each unique email is looked up exactly once; lookups run concurrently with a bounded semaphore.
+// Misses (unknown email, empty email) write an explicit empty-string pointer so the settings
+// converter always overwrites any previously-stored username in the database.
+// Transport errors are returned and the request fails — stale LFIDs are never silently kept.
+func (s *ProjectsService) enrichAllRoleFields(
+	ctx context.Context,
+	slices [][]*projsvc.UserInfo,
+	singles []*projsvc.UserInfo,
+) error {
+	if s.UserReader == nil {
+		return domain.ErrInternal
+	}
+
+	// Gather all entries grouped by email; clear username immediately for entries without an email.
+	type group struct{ users []*projsvc.UserInfo }
+	byEmail := make(map[string]*group)
+
+	gather := func(u *projsvc.UserInfo) {
+		if u == nil {
+			return
+		}
+		if u.Email == nil || *u.Email == "" {
+			u.Username = misc.StringPtr("")
+			return
+		}
+		eg := byEmail[*u.Email]
+		if eg == nil {
+			eg = &group{}
+			byEmail[*u.Email] = eg
+		}
+		eg.users = append(eg.users, u)
+	}
+
+	for _, slice := range slices {
+		for _, u := range slice {
+			gather(u)
+		}
+	}
+	for _, u := range singles {
+		gather(u)
+	}
+
+	if len(byEmail) == 0 {
 		return nil
 	}
+
+	// Look up each unique email concurrently.
+	results := make(map[string]string, len(byEmail))
+	var mu sync.Mutex
 	const maxConcurrent = 8
 	g, gCtx := errgroup.WithContext(ctx)
 	sem := make(chan struct{}, maxConcurrent)
-	for _, u := range users {
-		u := u
+
+	for email := range byEmail {
+		email := email
 		g.Go(func() error {
 			sem <- struct{}{}
 			defer func() { <-sem }()
-			return s.enrichSingleUser(gCtx, u)
+			username, err := s.UserReader.UsernameByEmail(gCtx, email)
+			if err != nil {
+				if errors.Is(err, domain.ErrUserNotFound) {
+					mu.Lock()
+					results[email] = ""
+					mu.Unlock()
+					return nil
+				}
+				return err
+			}
+			mu.Lock()
+			results[email] = username
+			mu.Unlock()
+			return nil
 		})
 	}
-	return g.Wait()
-}
 
-// enrichSingleUser enriches one UserInfo entry in place; see enrichUserSlice for full semantics.
-func (s *ProjectsService) enrichSingleUser(ctx context.Context, u *projsvc.UserInfo) error {
-	if u == nil {
-		return nil
-	}
-	if u.Email == nil || *u.Email == "" {
-		u.Username = nil
-		return nil
-	}
-	username, err := s.UserReader.UsernameByEmail(ctx, *u.Email)
-	if err != nil {
-		if errors.Is(err, domain.ErrUserNotFound) {
-			u.Username = nil
-			return nil
-		}
+	if err := g.Wait(); err != nil {
 		return err
 	}
-	u.Username = &username
+
+	// Apply resolved usernames — empty string clears any previously-stored value.
+	for email, eg := range byEmail {
+		username := results[email]
+		for _, u := range eg.users {
+			u.Username = misc.StringPtr(username)
+		}
+	}
 	return nil
 }

--- a/internal/service/project_operations.go
+++ b/internal/service/project_operations.go
@@ -760,12 +760,21 @@ func isCrowdfundingOnly(fundingModels []string) bool {
 // If the email is missing or does not match a registered user the username is cleared to nil.
 // Any transport error from the auth service is returned and the calling request fails.
 func (s *ProjectsService) enrichUserSlice(ctx context.Context, users []*projsvc.UserInfo) error {
-	for _, u := range users {
-		if err := s.enrichSingleUser(ctx, u); err != nil {
-			return err
-		}
+	if len(users) == 0 {
+		return nil
 	}
-	return nil
+	const maxConcurrent = 8
+	g, gCtx := errgroup.WithContext(ctx)
+	sem := make(chan struct{}, maxConcurrent)
+	for _, u := range users {
+		u := u
+		g.Go(func() error {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			return s.enrichSingleUser(gCtx, u)
+		})
+	}
+	return g.Wait()
 }
 
 // enrichSingleUser enriches one UserInfo entry in place; see enrichUserSlice for full semantics.

--- a/internal/service/project_operations_test.go
+++ b/internal/service/project_operations_test.go
@@ -1027,6 +1027,42 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 			expectedErr: domain.ErrInternal,
 		},
 		{
+			// Regression: if a writer had a previously-stored username and the auth service can no longer
+			// resolve their email, the stale username must be overwritten (not silently preserved).
+			name: "unknown email with previously-stored username — stale username cleared",
+			payload: &projsvc.UpdateProjectSettingsPayload{
+				UID:     misc.StringPtr("project-uid-1"),
+				IfMatch: misc.StringPtr("1"),
+				Writers: []*projsvc.UserInfo{
+					{Username: misc.StringPtr("stale-lfid"), Name: misc.StringPtr("Old User"), Email: misc.StringPtr("gone@example.com")},
+				},
+			},
+			setupUserReader: func(mockUserReader *domain.MockUserReader) {
+				mockUserReader.On("UsernameByEmail", mock.Anything, "gone@example.com").Return("", domain.ErrUserNotFound)
+			},
+			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
+				// Existing settings already have a writer with the same email and a stored LFID.
+				existingSettings := &models.ProjectSettings{
+					UID: "project-uid-1",
+					Writers: []models.UserInfo{
+						{Email: "gone@example.com", Username: "stale-lfid"},
+					},
+				}
+				projectDB := &models.ProjectBase{UID: "project-uid-1"}
+				mockRepo.On("ProjectExists", mock.Anything, "project-uid-1").Return(true, nil)
+				mockRepo.On("GetProjectSettings", mock.Anything, "project-uid-1").Return(existingSettings, nil)
+				// Username must be "" — the stale "stale-lfid" must not be preserved.
+				mockRepo.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
+					return len(s.Writers) == 1 && s.Writers[0].Username == ""
+				}), uint64(1)).Return(nil)
+				mockRepo.On("GetProjectBase", mock.Anything, "project-uid-1").Return(projectDB, nil)
+				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("SendAccessMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("SendProjectEventMessage", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
 			name:        "service not ready",
 			payload:     &projsvc.UpdateProjectSettingsPayload{UID: misc.StringPtr("project-uid-1")},
 			setupMocks:  func(_ *domain.MockProjectRepository, _ *domain.MockMessageBuilder) {},

--- a/internal/service/project_operations_test.go
+++ b/internal/service/project_operations_test.go
@@ -135,12 +135,13 @@ func TestProjectsService_GetProjects(t *testing.T) {
 
 func TestProjectsService_CreateProject(t *testing.T) {
 	tests := []struct {
-		name        string
-		payload     *projsvc.CreateProjectPayload
-		setupMocks  func(*domain.MockProjectRepository, *domain.MockMessageBuilder)
-		wantErr     bool
-		expectedErr error
-		validate    func(*testing.T, *projsvc.ProjectFull)
+		name            string
+		payload         *projsvc.CreateProjectPayload
+		setupMocks      func(*domain.MockProjectRepository, *domain.MockMessageBuilder)
+		setupUserReader func(*domain.MockUserReader)
+		wantErr         bool
+		expectedErr     error
+		validate        func(*testing.T, *projsvc.ProjectFull)
 	}{
 		{
 			name: "successful project creation",
@@ -219,16 +220,46 @@ func TestProjectsService_CreateProject(t *testing.T) {
 			wantErr:     true,
 			expectedErr: domain.ErrInternal,
 		},
+		{
+			name: "create project — writer username enriched from email",
+			payload: &projsvc.CreateProjectPayload{
+				Slug:        "new-project",
+				Name:        "New Project",
+				Description: "Desc",
+				Writers: []*projsvc.UserInfo{
+					{Username: misc.StringPtr("UNTRUSTED"), Name: misc.StringPtr("Carol"), Email: misc.StringPtr("carol@example.com")},
+				},
+			},
+			setupUserReader: func(mockUserReader *domain.MockUserReader) {
+				mockUserReader.On("UsernameByEmail", mock.Anything, "carol@example.com").Return("carol-lfid", nil)
+			},
+			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
+				mockRepo.On("ProjectSlugExists", mock.Anything, "new-project").Return(false, nil)
+				mockRepo.On("CreateProject", mock.Anything, mock.AnythingOfType("*models.ProjectBase"), mock.MatchedBy(func(s *models.ProjectSettings) bool {
+					return len(s.Writers) == 1 && s.Writers[0].Username == "carol-lfid"
+				})).Return(nil)
+				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(2)
+				mockBuilder.On("SendAccessMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			wantErr: false,
+			validate: func(t *testing.T, result *projsvc.ProjectFull) {
+				require.NotNil(t, result)
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			service, mockRepo, mockBuilder, mockAuth := setupServiceForTesting()
+			mockUserReader := service.UserReader.(*domain.MockUserReader)
 
 			if tt.name == "service not ready" {
 				service.ProjectRepository = nil
 			}
 
+			if tt.setupUserReader != nil {
+				tt.setupUserReader(mockUserReader)
+			}
 			tt.setupMocks(mockRepo, mockBuilder)
 
 			result, err := service.CreateProject(context.Background(), tt.payload)
@@ -250,6 +281,7 @@ func TestProjectsService_CreateProject(t *testing.T) {
 			mockRepo.AssertExpectations(t)
 			mockBuilder.AssertExpectations(t)
 			mockAuth.AssertExpectations(t)
+			mockUserReader.AssertExpectations(t)
 		})
 	}
 }
@@ -843,11 +875,12 @@ func TestProjectsService_UpdateProjectBase(t *testing.T) {
 
 func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 	tests := []struct {
-		name        string
-		payload     *projsvc.UpdateProjectSettingsPayload
-		setupMocks  func(*domain.MockProjectRepository, *domain.MockMessageBuilder)
-		wantErr     bool
-		expectedErr error
+		name            string
+		payload         *projsvc.UpdateProjectSettingsPayload
+		setupMocks      func(*domain.MockProjectRepository, *domain.MockMessageBuilder)
+		setupUserReader func(*domain.MockUserReader)
+		wantErr         bool
+		expectedErr     error
 	}{
 		{
 			name: "successful update — publishes FGA update_access message with writers",
@@ -857,6 +890,9 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				Writers: []*projsvc.UserInfo{
 					{Username: misc.StringPtr("alice"), Name: misc.StringPtr("Alice"), Email: misc.StringPtr("alice@example.com"), Avatar: misc.StringPtr("")},
 				},
+			},
+			setupUserReader: func(mockUserReader *domain.MockUserReader) {
+				mockUserReader.On("UsernameByEmail", mock.Anything, "alice@example.com").Return("alice", nil)
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
 				existingSettings := &models.ProjectSettings{UID: "project-uid-1", CreatedAt: func() *time.Time { t := time.Now(); return &t }()}
@@ -890,6 +926,104 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				mockBuilder.On("SendProjectEventMessage", mock.Anything, mock.AnythingOfType("string"), mock.Anything).Return(nil)
 			},
 			wantErr: false,
+		},
+		{
+			name: "username enriched from email — caller-supplied username is replaced",
+			payload: &projsvc.UpdateProjectSettingsPayload{
+				UID:     misc.StringPtr("project-uid-1"),
+				IfMatch: misc.StringPtr("1"),
+				Writers: []*projsvc.UserInfo{
+					{Username: misc.StringPtr("UNTRUSTED"), Name: misc.StringPtr("Bob"), Email: misc.StringPtr("bob@example.com")},
+				},
+			},
+			setupUserReader: func(mockUserReader *domain.MockUserReader) {
+				mockUserReader.On("UsernameByEmail", mock.Anything, "bob@example.com").Return("real-bob", nil)
+			},
+			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
+				existingSettings := &models.ProjectSettings{UID: "project-uid-1"}
+				projectDB := &models.ProjectBase{UID: "project-uid-1", Public: false}
+				mockRepo.On("ProjectExists", mock.Anything, "project-uid-1").Return(true, nil)
+				mockRepo.On("GetProjectSettings", mock.Anything, "project-uid-1").Return(existingSettings, nil)
+				mockRepo.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
+					return len(s.Writers) == 1 && s.Writers[0].Username == "real-bob"
+				}), uint64(1)).Return(nil)
+				mockRepo.On("GetProjectBase", mock.Anything, "project-uid-1").Return(projectDB, nil)
+				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("SendAccessMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("SendProjectEventMessage", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "unknown email — username cleared, request succeeds",
+			payload: &projsvc.UpdateProjectSettingsPayload{
+				UID:     misc.StringPtr("project-uid-1"),
+				IfMatch: misc.StringPtr("1"),
+				Writers: []*projsvc.UserInfo{
+					{Username: misc.StringPtr("some-user"), Name: misc.StringPtr("Unknown"), Email: misc.StringPtr("nobody@example.com")},
+				},
+			},
+			setupUserReader: func(mockUserReader *domain.MockUserReader) {
+				mockUserReader.On("UsernameByEmail", mock.Anything, "nobody@example.com").Return("", domain.ErrUserNotFound)
+			},
+			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
+				existingSettings := &models.ProjectSettings{UID: "project-uid-1"}
+				projectDB := &models.ProjectBase{UID: "project-uid-1"}
+				mockRepo.On("ProjectExists", mock.Anything, "project-uid-1").Return(true, nil)
+				mockRepo.On("GetProjectSettings", mock.Anything, "project-uid-1").Return(existingSettings, nil)
+				mockRepo.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
+					return len(s.Writers) == 1 && s.Writers[0].Username == ""
+				}), uint64(1)).Return(nil)
+				mockRepo.On("GetProjectBase", mock.Anything, "project-uid-1").Return(projectDB, nil)
+				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("SendAccessMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("SendProjectEventMessage", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing email — username cleared",
+			payload: &projsvc.UpdateProjectSettingsPayload{
+				UID:     misc.StringPtr("project-uid-1"),
+				IfMatch: misc.StringPtr("1"),
+				Auditors: []*projsvc.UserInfo{
+					{Name: misc.StringPtr("NoEmail")},
+				},
+			},
+			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
+				existingSettings := &models.ProjectSettings{UID: "project-uid-1"}
+				projectDB := &models.ProjectBase{UID: "project-uid-1"}
+				mockRepo.On("ProjectExists", mock.Anything, "project-uid-1").Return(true, nil)
+				mockRepo.On("GetProjectSettings", mock.Anything, "project-uid-1").Return(existingSettings, nil)
+				mockRepo.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
+					return len(s.Auditors) == 1 && s.Auditors[0].Username == ""
+				}), uint64(1)).Return(nil)
+				mockRepo.On("GetProjectBase", mock.Anything, "project-uid-1").Return(projectDB, nil)
+				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("SendAccessMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("SendProjectEventMessage", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "auth service transport error — request fails",
+			payload: &projsvc.UpdateProjectSettingsPayload{
+				UID:     misc.StringPtr("project-uid-1"),
+				IfMatch: misc.StringPtr("1"),
+				Writers: []*projsvc.UserInfo{
+					{Name: misc.StringPtr("Eve"), Email: misc.StringPtr("eve@example.com")},
+				},
+			},
+			setupUserReader: func(mockUserReader *domain.MockUserReader) {
+				mockUserReader.On("UsernameByEmail", mock.Anything, "eve@example.com").Return("", assert.AnError)
+			},
+			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
+				existingSettings := &models.ProjectSettings{UID: "project-uid-1"}
+				mockRepo.On("ProjectExists", mock.Anything, "project-uid-1").Return(true, nil)
+				mockRepo.On("GetProjectSettings", mock.Anything, "project-uid-1").Return(existingSettings, nil)
+			},
+			wantErr:     true,
+			expectedErr: domain.ErrInternal,
 		},
 		{
 			name:        "service not ready",
@@ -929,11 +1063,15 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			service, mockRepo, mockBuilder, mockAuth := setupServiceForTesting()
+			mockUserReader := service.UserReader.(*domain.MockUserReader)
 
 			if tt.expectedErr == domain.ErrServiceUnavailable {
 				service.ProjectRepository = nil
 			}
 
+			if tt.setupUserReader != nil {
+				tt.setupUserReader(mockUserReader)
+			}
 			tt.setupMocks(mockRepo, mockBuilder)
 
 			result, err := service.UpdateProjectSettings(context.Background(), tt.payload)
@@ -952,6 +1090,7 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 			mockRepo.AssertExpectations(t)
 			mockBuilder.AssertExpectations(t)
 			mockAuth.AssertExpectations(t)
+			mockUserReader.AssertExpectations(t)
 		})
 	}
 }

--- a/internal/service/project_operations_test.go
+++ b/internal/service/project_operations_test.go
@@ -660,6 +660,7 @@ func TestProjectsService_DeleteProject(t *testing.T) {
 				service.LinkRepository = &domain.MockLinkRepository{}
 				service.FolderRepository = &domain.MockFolderRepository{}
 				service.MessageBuilder = mockBuilder
+				service.UserReader = &domain.MockUserReader{}
 			} else {
 				// Use default setup
 				service, mockRepo, mockBuilder, mockAuth = setupServiceForTesting()

--- a/internal/service/project_service.go
+++ b/internal/service/project_service.go
@@ -30,7 +30,8 @@ func NewProjectsService(auth domain.Authenticator, config ServiceConfig) *Projec
 // ServiceReady checks if the service is ready for use.
 func (s *ProjectsService) ServiceReady() bool {
 	return s.ProjectRepository != nil && s.MessageBuilder != nil &&
-		s.DocumentRepository != nil && s.LinkRepository != nil && s.FolderRepository != nil
+		s.DocumentRepository != nil && s.LinkRepository != nil && s.FolderRepository != nil &&
+		s.UserReader != nil
 }
 
 // ServiceConfig is the configuration for the ProjectsService.

--- a/internal/service/project_service_test.go
+++ b/internal/service/project_service_test.go
@@ -54,6 +54,7 @@ func TestProjectsService_ServiceReady(t *testing.T) {
 					FolderRepository:   &domain.MockFolderRepository{},
 					MessageBuilder:     &domain.MockMessageBuilder{},
 					Auth:               &auth.MockJWTAuth{},
+					UserReader:         &domain.MockUserReader{},
 				}
 			},
 			expectedReady: true,
@@ -100,10 +101,26 @@ func TestProjectsService_ServiceReady(t *testing.T) {
 					LinkRepository:     &domain.MockLinkRepository{},
 					FolderRepository:   &domain.MockFolderRepository{},
 					MessageBuilder:     &domain.MockMessageBuilder{},
+					UserReader:         &domain.MockUserReader{},
 					Auth:               nil,
 				}
 			},
 			expectedReady: true,
+		},
+		{
+			name: "service not ready - missing user reader",
+			setupService: func() *ProjectsService {
+				return &ProjectsService{
+					ProjectRepository:  &domain.MockProjectRepository{},
+					DocumentRepository: &domain.MockDocumentRepository{},
+					LinkRepository:     &domain.MockLinkRepository{},
+					FolderRepository:   &domain.MockFolderRepository{},
+					MessageBuilder:     &domain.MockMessageBuilder{},
+					UserReader:         nil,
+					Auth:               &auth.MockJWTAuth{},
+				}
+			},
+			expectedReady: false,
 		},
 	}
 

--- a/internal/service/project_service_test.go
+++ b/internal/service/project_service_test.go
@@ -145,6 +145,7 @@ func setupServiceForTesting() (*ProjectsService, *domain.MockProjectRepository, 
 	mockRepo := &domain.MockProjectRepository{}
 	mockBuilder := &domain.MockMessageBuilder{}
 	mockAuth := &auth.MockJWTAuth{}
+	mockUserReader := &domain.MockUserReader{}
 
 	service := NewProjectsService(mockAuth, ServiceConfig{})
 	service.ProjectRepository = mockRepo
@@ -152,6 +153,7 @@ func setupServiceForTesting() (*ProjectsService, *domain.MockProjectRepository, 
 	service.LinkRepository = &domain.MockLinkRepository{}
 	service.FolderRepository = &domain.MockFolderRepository{}
 	service.MessageBuilder = mockBuilder
+	service.UserReader = mockUserReader
 
 	return service, mockRepo, mockBuilder, mockAuth
 }

--- a/pkg/constants/nats.go
+++ b/pkg/constants/nats.go
@@ -95,4 +95,8 @@ const (
 	// AuthUserMetadataReadSubject is the subject for looking up a user's profile metadata by principal.
 	// The subject is of the form: lfx.auth-service.user_metadata.read
 	AuthUserMetadataReadSubject = "lfx.auth-service.user_metadata.read"
+
+	// AuthEmailToUsernameSubject resolves a registered LFID username by primary email.
+	// Request: plain-text email. Reply: plain-text username on success, JSON error envelope on miss.
+	AuthEmailToUsernameSubject = "lfx.auth-service.email_to_username"
 )


### PR DESCRIPTION
## Summary

- Server-side username enrichment added to `PUT /projects/{uid}/settings` and `POST /projects` — the caller-supplied `username` on each `UserInfo` (writers, auditors, meeting-coordinators, executive-director, program-manager, opportunity-owner) is always replaced with the authoritative LFID from `lfx.auth-service.email_to_username`
- The caller does not own the assignee's login profile, so their supplied username is untrustworthy; FGA access control keys off this value, making it security-sensitive
- Lookup miss (unregistered email) → `username` cleared to nil, request still succeeds; transport error → request fails with 500

## Changes

- `pkg/constants/nats.go` — add `AuthEmailToUsernameSubject = "lfx.auth-service.email_to_username"`
- `internal/domain/errors.go` — add `ErrUserNotFound` sentinel
- `internal/domain/user.go` — extend `UserReader` interface with `UsernameByEmail`
- `internal/infrastructure/nats/user_reader.go` — implement `UsernameByEmail` via NATS request/reply to `lfx.auth-service.email_to_username` (plain-text email in, plain-text LFID out, JSON error envelope on miss)
- `internal/service/project_operations.go` — add `enrichUserSlice` / `enrichSingleUser`; wire into `CreateProject` and `UpdateProjectSettings` before payload is converted to domain struct
- Tests updated across `internal/service` and `cmd/project-api`; 5 new test cases covering happy path, caller-supplied username override, lookup miss, missing email, and transport error

## Ticket

[LFXV-1961](https://linuxfoundation.atlassian.net/browse/LFXV2-1961)

🤖 Generated with [Claude Code](https://claude.ai/code)