### PR TITLE
[LFXV2-1961] Enrich name and avatar from auth service after LFID lookup

### DIFF
--- a/cmd/project-api/service_endpoint_project_test.go
+++ b/cmd/project-api/service_endpoint_project_test.go
@@ -156,6 +156,10 @@ func TestCreateProject(t *testing.T) {
 				mockUserReader.On("UsernameByEmail", mock.Anything, "user2@example.com").Return("user2", nil)
 				mockUserReader.On("UsernameByEmail", mock.Anything, "user3@example.com").Return("user3", nil)
 				mockUserReader.On("UsernameByEmail", mock.Anything, "user4@example.com").Return("user4", nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "user1").Return((*domain.UserMetadata)(nil), nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "user2").Return((*domain.UserMetadata)(nil), nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "user3").Return((*domain.UserMetadata)(nil), nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "user4").Return((*domain.UserMetadata)(nil), nil)
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockMsg *domain.MockMessageBuilder) {
 				// Mock parent project exists (for ParentUID validation)

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -7,9 +7,20 @@ import "context"
 
 // UserMetadata holds profile information for a user returned by the auth service.
 type UserMetadata struct {
-	Name       string
-	GivenName  string
-	FamilyName string
+	Picture       string
+	Zoneinfo      string
+	Name          string
+	GivenName     string
+	FamilyName    string
+	JobTitle      string
+	Organization  string
+	Country       string
+	StateProvince string
+	City          string
+	Address       string
+	PostalCode    string
+	PhoneNumber   string
+	TShirtSize    string
 }
 
 // UserReader retrieves user profile information from the auth service.

--- a/internal/infrastructure/nats/user_reader.go
+++ b/internal/infrastructure/nats/user_reader.go
@@ -139,9 +139,17 @@ func (u *UserReaderNATS) UsernameByEmail(ctx context.Context, email string) (str
 
 	// Only attempt JSON decode when the trimmed body starts with '{' to avoid misinterpreting a
 	// valid plain-text username that happens to be valid JSON (e.g. a numeric string).
+	// If the body parses as any valid JSON object, treat it as an error envelope: the current
+	// contract is plain-text on success, so a JSON body is always an error or an unexpected format
+	// — neither of which should be returned as a username and propagated into access control.
 	if body[0] == '{' {
 		var errResp emailToUsernameErrorResponse
-		if json.Unmarshal([]byte(body), &errResp) == nil && !errResp.Success {
+		if json.Unmarshal([]byte(body), &errResp) == nil {
+			if !errResp.Success {
+				return "", domain.ErrUserNotFound
+			}
+			// Parsed successfully but success=true — unexpected JSON success envelope from the
+			// auth service; treat as not found rather than leak the raw JSON as a username.
 			return "", domain.ErrUserNotFound
 		}
 	}

--- a/internal/infrastructure/nats/user_reader.go
+++ b/internal/infrastructure/nats/user_reader.go
@@ -24,9 +24,20 @@ type userMetadataNATSResponse struct {
 
 // userMetadataNATSDataBody holds the profile fields from the auth-service response.
 type userMetadataNATSDataBody struct {
-	Name       *string `json:"name,omitempty"`
-	GivenName  *string `json:"given_name,omitempty"`
-	FamilyName *string `json:"family_name,omitempty"`
+	Picture       *string `json:"picture,omitempty"`
+	Zoneinfo      *string `json:"zoneinfo,omitempty"`
+	Name          *string `json:"name,omitempty"`
+	GivenName     *string `json:"given_name,omitempty"`
+	FamilyName    *string `json:"family_name,omitempty"`
+	JobTitle      *string `json:"job_title,omitempty"`
+	Organization  *string `json:"organization,omitempty"`
+	Country       *string `json:"country,omitempty"`
+	StateProvince *string `json:"state_province,omitempty"`
+	City          *string `json:"city,omitempty"`
+	Address       *string `json:"address,omitempty"`
+	PostalCode    *string `json:"postal_code,omitempty"`
+	PhoneNumber   *string `json:"phone_number,omitempty"`
+	TShirtSize    *string `json:"t_shirt_size,omitempty"`
 }
 
 // UserReaderNATS implements domain.UserReader via NATS requests to the auth service.
@@ -53,15 +64,49 @@ func (u *UserReaderNATS) UserMetadataByPrincipal(ctx context.Context, principal 
 		return nil, fmt.Errorf("user metadata not found for principal")
 	}
 
+	d := response.Data
 	result := &domain.UserMetadata{}
-	if response.Data.Name != nil {
-		result.Name = *response.Data.Name
+	if d.Picture != nil {
+		result.Picture = *d.Picture
 	}
-	if response.Data.GivenName != nil {
-		result.GivenName = *response.Data.GivenName
+	if d.Zoneinfo != nil {
+		result.Zoneinfo = *d.Zoneinfo
 	}
-	if response.Data.FamilyName != nil {
-		result.FamilyName = *response.Data.FamilyName
+	if d.Name != nil {
+		result.Name = *d.Name
+	}
+	if d.GivenName != nil {
+		result.GivenName = *d.GivenName
+	}
+	if d.FamilyName != nil {
+		result.FamilyName = *d.FamilyName
+	}
+	if d.JobTitle != nil {
+		result.JobTitle = *d.JobTitle
+	}
+	if d.Organization != nil {
+		result.Organization = *d.Organization
+	}
+	if d.Country != nil {
+		result.Country = *d.Country
+	}
+	if d.StateProvince != nil {
+		result.StateProvince = *d.StateProvince
+	}
+	if d.City != nil {
+		result.City = *d.City
+	}
+	if d.Address != nil {
+		result.Address = *d.Address
+	}
+	if d.PostalCode != nil {
+		result.PostalCode = *d.PostalCode
+	}
+	if d.PhoneNumber != nil {
+		result.PhoneNumber = *d.PhoneNumber
+	}
+	if d.TShirtSize != nil {
+		result.TShirtSize = *d.TShirtSize
 	}
 	return result, nil
 }

--- a/internal/infrastructure/nats/user_reader.go
+++ b/internal/infrastructure/nats/user_reader.go
@@ -61,7 +61,10 @@ func (u *UserReaderNATS) UserMetadataByPrincipal(ctx context.Context, principal 
 	}
 
 	if !response.Success || response.Data == nil {
-		return nil, fmt.Errorf("user metadata not found for principal %s: %s", principal, response.Error)
+		if response.Error != "" {
+			return nil, fmt.Errorf("user metadata not found: %s", response.Error)
+		}
+		return nil, fmt.Errorf("user metadata not found")
 	}
 
 	d := response.Data

--- a/internal/infrastructure/nats/user_reader.go
+++ b/internal/infrastructure/nats/user_reader.go
@@ -111,13 +111,6 @@ func (u *UserReaderNATS) UserMetadataByPrincipal(ctx context.Context, principal 
 	return result, nil
 }
 
-// emailToUsernameErrorResponse mirrors the auth-service error envelope for lfx.auth-service.email_to_username.
-// The type is internal to the auth service, so we keep a local copy of the relevant fields.
-type emailToUsernameErrorResponse struct {
-	Success bool   `json:"success"`
-	Error   string `json:"error,omitempty"`
-}
-
 // UsernameByEmail resolves the registered LFID username for the given primary email address.
 // The auth service replies with a plain-text username on success, or a JSON error envelope on miss.
 func (u *UserReaderNATS) UsernameByEmail(ctx context.Context, email string) (string, error) {
@@ -137,21 +130,11 @@ func (u *UserReaderNATS) UsernameByEmail(ctx context.Context, email string) (str
 		return "", domain.ErrUserNotFound
 	}
 
-	// Only attempt JSON decode when the trimmed body starts with '{' to avoid misinterpreting a
-	// valid plain-text username that happens to be valid JSON (e.g. a numeric string).
-	// If the body parses as any valid JSON object, treat it as an error envelope: the current
-	// contract is plain-text on success, so a JSON body is always an error or an unexpected format
-	// — neither of which should be returned as a username and propagated into access control.
+	// Any object-shaped response (starts with '{') is an error envelope or contract violation.
+	// Never return JSON as a username — it would propagate garbage into access control.
+	// This covers both well-formed error envelopes and malformed JSON blobs.
 	if body[0] == '{' {
-		var errResp emailToUsernameErrorResponse
-		if json.Unmarshal([]byte(body), &errResp) == nil {
-			if !errResp.Success {
-				return "", domain.ErrUserNotFound
-			}
-			// Parsed successfully but success=true — unexpected JSON success envelope from the
-			// auth service; treat as not found rather than leak the raw JSON as a username.
-			return "", domain.ErrUserNotFound
-		}
+		return "", domain.ErrUserNotFound
 	}
 
 	return body, nil

--- a/internal/infrastructure/nats/user_reader.go
+++ b/internal/infrastructure/nats/user_reader.go
@@ -61,7 +61,7 @@ func (u *UserReaderNATS) UserMetadataByPrincipal(ctx context.Context, principal 
 	}
 
 	if !response.Success || response.Data == nil {
-		return nil, fmt.Errorf("user metadata not found for principal")
+		return nil, fmt.Errorf("user metadata not found for principal %s: %s", principal, response.Error)
 	}
 
 	d := response.Data

--- a/internal/infrastructure/nats/user_reader_test.go
+++ b/internal/infrastructure/nats/user_reader_test.go
@@ -68,6 +68,11 @@ func TestUserReaderNATS_UsernameByEmail(t *testing.T) {
 			wantErr: domain.ErrUserNotFound,
 		},
 		{
+			name:    "malformed JSON object returns ErrUserNotFound instead of leaking raw body as username",
+			reply:   replyMsg([]byte(`{"success":"true"}`)),
+			wantErr: domain.ErrUserNotFound,
+		},
+		{
 			name:       "transport error is wrapped and returned",
 			reply:      nil,
 			replyErr:   errors.New("nats: connection closed"),

--- a/internal/infrastructure/nats/user_reader_test.go
+++ b/internal/infrastructure/nats/user_reader_test.go
@@ -109,7 +109,8 @@ func TestUserReaderNATS_UsernameByEmail(t *testing.T) {
 
 func TestUserReaderNATS_UserMetadataByPrincipal(t *testing.T) {
 	marshalSuccess := func(data map[string]interface{}) []byte {
-		b, _ := json.Marshal(map[string]interface{}{"success": true, "data": data})
+		b, err := json.Marshal(map[string]interface{}{"success": true, "data": data})
+		require.NoError(t, err)
 		return b
 	}
 

--- a/internal/infrastructure/nats/user_reader_test.go
+++ b/internal/infrastructure/nats/user_reader_test.go
@@ -19,54 +19,57 @@ import (
 	"github.com/linuxfoundation/lfx-v2-project-service/pkg/constants"
 )
 
+// replyMsg builds a minimal NATS reply message for success cases.
+// Transport-error cases should pass nil as the reply directly.
 func replyMsg(data []byte) *natsgo.Msg { return &natsgo.Msg{Data: data} }
 
 func TestUserReaderNATS_UsernameByEmail(t *testing.T) {
 	tests := []struct {
 		name       string
-		replyData  []byte
+		reply      *natsgo.Msg // nil simulates a transport error
 		replyErr   error
 		wantUser   string
 		wantErr    error
 		wantErrStr string
 	}{
 		{
-			name:      "plain-text username returned on success",
-			replyData: []byte("alice"),
-			wantUser:  "alice",
+			name:     "plain-text username returned on success",
+			reply:    replyMsg([]byte("alice")),
+			wantUser: "alice",
 		},
 		{
-			name:      "trailing newline trimmed from username",
-			replyData: []byte("alice\n"),
-			wantUser:  "alice",
+			name:     "trailing newline trimmed from username",
+			reply:    replyMsg([]byte("alice\n")),
+			wantUser: "alice",
 		},
 		{
-			name:      "leading and trailing whitespace trimmed",
-			replyData: []byte("  alice  "),
-			wantUser:  "alice",
+			name:     "leading and trailing whitespace trimmed",
+			reply:    replyMsg([]byte("  alice  ")),
+			wantUser: "alice",
 		},
 		{
-			name:      "empty body returns ErrUserNotFound",
-			replyData: []byte(""),
-			wantErr:   domain.ErrUserNotFound,
+			name:    "empty body returns ErrUserNotFound",
+			reply:   replyMsg([]byte("")),
+			wantErr: domain.ErrUserNotFound,
 		},
 		{
-			name:      "whitespace-only body returns ErrUserNotFound",
-			replyData: []byte("   \n  "),
-			wantErr:   domain.ErrUserNotFound,
+			name:    "whitespace-only body returns ErrUserNotFound",
+			reply:   replyMsg([]byte("   \n  ")),
+			wantErr: domain.ErrUserNotFound,
 		},
 		{
-			name:      "JSON error envelope returns ErrUserNotFound",
-			replyData: []byte(`{"success":false,"error":"user not found"}`),
-			wantErr:   domain.ErrUserNotFound,
+			name:    "JSON error envelope returns ErrUserNotFound",
+			reply:   replyMsg([]byte(`{"success":false,"error":"user not found"}`)),
+			wantErr: domain.ErrUserNotFound,
 		},
 		{
-			name:      "JSON success envelope returns ErrUserNotFound instead of leaking JSON as username",
-			replyData: []byte(`{"success":true,"username":"alice"}`),
-			wantErr:   domain.ErrUserNotFound,
+			name:    "JSON success envelope returns ErrUserNotFound instead of leaking JSON as username",
+			reply:   replyMsg([]byte(`{"success":true,"username":"alice"}`)),
+			wantErr: domain.ErrUserNotFound,
 		},
 		{
 			name:       "transport error is wrapped and returned",
+			reply:      nil,
 			replyErr:   errors.New("nats: connection closed"),
 			wantErrStr: "email_to_username request failed",
 		},
@@ -77,19 +80,20 @@ func TestUserReaderNATS_UsernameByEmail(t *testing.T) {
 			mockConn := &MockNATSConn{}
 			mockConn.On("RequestMsgWithContext", mock.Anything, mock.MatchedBy(func(msg *natsgo.Msg) bool {
 				return msg.Subject == constants.AuthEmailToUsernameSubject
-			})).Return(replyMsg(tt.replyData), tt.replyErr)
+			})).Return(tt.reply, tt.replyErr)
 
 			reader := &UserReaderNATS{NatsConn: mockConn}
 			got, err := reader.UsernameByEmail(context.Background(), "test@example.com")
 
-			if tt.wantErr != nil {
+			switch {
+			case tt.wantErr != nil:
 				assert.ErrorIs(t, err, tt.wantErr)
 				assert.Empty(t, got)
-			} else if tt.wantErrStr != "" {
+			case tt.wantErrStr != "":
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErrStr)
 				assert.Empty(t, got)
-			} else {
+			default:
 				require.NoError(t, err)
 				assert.Equal(t, tt.wantUser, got)
 			}
@@ -106,14 +110,14 @@ func TestUserReaderNATS_UserMetadataByPrincipal(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		replyData  []byte
+		reply      *natsgo.Msg // nil simulates a transport error
 		replyErr   error
 		wantMeta   *domain.UserMetadata
 		wantErrStr string
 	}{
 		{
 			name: "all fields populated",
-			replyData: marshalSuccess(map[string]interface{}{
+			reply: replyMsg(marshalSuccess(map[string]interface{}{
 				"name":           "Alice Example",
 				"given_name":     "Alice",
 				"family_name":    "Example",
@@ -128,7 +132,7 @@ func TestUserReaderNATS_UserMetadataByPrincipal(t *testing.T) {
 				"postal_code":    "94105",
 				"phone_number":   "+14155550100",
 				"t_shirt_size":   "M",
-			}),
+			})),
 			wantMeta: &domain.UserMetadata{
 				Name:          "Alice Example",
 				GivenName:     "Alice",
@@ -147,22 +151,23 @@ func TestUserReaderNATS_UserMetadataByPrincipal(t *testing.T) {
 			},
 		},
 		{
-			name:      "partial fields — omitted fields remain zero-value",
-			replyData: marshalSuccess(map[string]interface{}{"name": "Bob"}),
-			wantMeta:  &domain.UserMetadata{Name: "Bob"},
+			name:     "partial fields — omitted fields remain zero-value",
+			reply:    replyMsg(marshalSuccess(map[string]interface{}{"name": "Bob"})),
+			wantMeta: &domain.UserMetadata{Name: "Bob"},
 		},
 		{
 			name:       "success=false returns error",
-			replyData:  []byte(`{"success":false,"error":"not found"}`),
+			reply:      replyMsg([]byte(`{"success":false,"error":"not found"}`)),
 			wantErrStr: "user metadata not found",
 		},
 		{
 			name:       "malformed JSON returns parse error",
-			replyData:  []byte(`not-json`),
+			reply:      replyMsg([]byte(`not-json`)),
 			wantErrStr: "failed to parse user_metadata response",
 		},
 		{
 			name:       "transport error is returned",
+			reply:      nil,
 			replyErr:   fmt.Errorf("nats: timeout"),
 			wantErrStr: "nats: timeout",
 		},
@@ -173,7 +178,7 @@ func TestUserReaderNATS_UserMetadataByPrincipal(t *testing.T) {
 			mockConn := &MockNATSConn{}
 			mockConn.On("RequestMsgWithContext", mock.Anything, mock.MatchedBy(func(msg *natsgo.Msg) bool {
 				return msg.Subject == constants.AuthUserMetadataReadSubject
-			})).Return(replyMsg(tt.replyData), tt.replyErr)
+			})).Return(tt.reply, tt.replyErr)
 
 			reader := &UserReaderNATS{NatsConn: mockConn}
 			got, err := reader.UserMetadataByPrincipal(context.Background(), "alice")

--- a/internal/infrastructure/nats/user_reader_test.go
+++ b/internal/infrastructure/nats/user_reader_test.go
@@ -1,0 +1,192 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package nats
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	natsgo "github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-project-service/internal/domain"
+	"github.com/linuxfoundation/lfx-v2-project-service/pkg/constants"
+)
+
+func replyMsg(data []byte) *natsgo.Msg { return &natsgo.Msg{Data: data} }
+
+func TestUserReaderNATS_UsernameByEmail(t *testing.T) {
+	tests := []struct {
+		name       string
+		replyData  []byte
+		replyErr   error
+		wantUser   string
+		wantErr    error
+		wantErrStr string
+	}{
+		{
+			name:      "plain-text username returned on success",
+			replyData: []byte("alice"),
+			wantUser:  "alice",
+		},
+		{
+			name:      "trailing newline trimmed from username",
+			replyData: []byte("alice\n"),
+			wantUser:  "alice",
+		},
+		{
+			name:      "leading and trailing whitespace trimmed",
+			replyData: []byte("  alice  "),
+			wantUser:  "alice",
+		},
+		{
+			name:      "empty body returns ErrUserNotFound",
+			replyData: []byte(""),
+			wantErr:   domain.ErrUserNotFound,
+		},
+		{
+			name:      "whitespace-only body returns ErrUserNotFound",
+			replyData: []byte("   \n  "),
+			wantErr:   domain.ErrUserNotFound,
+		},
+		{
+			name:      "JSON error envelope returns ErrUserNotFound",
+			replyData: []byte(`{"success":false,"error":"user not found"}`),
+			wantErr:   domain.ErrUserNotFound,
+		},
+		{
+			name:      "JSON success envelope returns ErrUserNotFound instead of leaking JSON as username",
+			replyData: []byte(`{"success":true,"username":"alice"}`),
+			wantErr:   domain.ErrUserNotFound,
+		},
+		{
+			name:       "transport error is wrapped and returned",
+			replyErr:   errors.New("nats: connection closed"),
+			wantErrStr: "email_to_username request failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockConn := &MockNATSConn{}
+			mockConn.On("RequestMsgWithContext", mock.Anything, mock.MatchedBy(func(msg *natsgo.Msg) bool {
+				return msg.Subject == constants.AuthEmailToUsernameSubject
+			})).Return(replyMsg(tt.replyData), tt.replyErr)
+
+			reader := &UserReaderNATS{NatsConn: mockConn}
+			got, err := reader.UsernameByEmail(context.Background(), "test@example.com")
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Empty(t, got)
+			} else if tt.wantErrStr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrStr)
+				assert.Empty(t, got)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantUser, got)
+			}
+			mockConn.AssertExpectations(t)
+		})
+	}
+}
+
+func TestUserReaderNATS_UserMetadataByPrincipal(t *testing.T) {
+	marshalSuccess := func(data map[string]interface{}) []byte {
+		b, _ := json.Marshal(map[string]interface{}{"success": true, "data": data})
+		return b
+	}
+
+	tests := []struct {
+		name       string
+		replyData  []byte
+		replyErr   error
+		wantMeta   *domain.UserMetadata
+		wantErrStr string
+	}{
+		{
+			name: "all fields populated",
+			replyData: marshalSuccess(map[string]interface{}{
+				"name":           "Alice Example",
+				"given_name":     "Alice",
+				"family_name":    "Example",
+				"picture":        "https://example.com/alice.png",
+				"zoneinfo":       "America/New_York",
+				"job_title":      "Engineer",
+				"organization":   "LF",
+				"country":        "US",
+				"state_province": "CA",
+				"city":           "San Francisco",
+				"address":        "1 Main St",
+				"postal_code":    "94105",
+				"phone_number":   "+14155550100",
+				"t_shirt_size":   "M",
+			}),
+			wantMeta: &domain.UserMetadata{
+				Name:          "Alice Example",
+				GivenName:     "Alice",
+				FamilyName:    "Example",
+				Picture:       "https://example.com/alice.png",
+				Zoneinfo:      "America/New_York",
+				JobTitle:      "Engineer",
+				Organization:  "LF",
+				Country:       "US",
+				StateProvince: "CA",
+				City:          "San Francisco",
+				Address:       "1 Main St",
+				PostalCode:    "94105",
+				PhoneNumber:   "+14155550100",
+				TShirtSize:    "M",
+			},
+		},
+		{
+			name:      "partial fields — omitted fields remain zero-value",
+			replyData: marshalSuccess(map[string]interface{}{"name": "Bob"}),
+			wantMeta:  &domain.UserMetadata{Name: "Bob"},
+		},
+		{
+			name:       "success=false returns error",
+			replyData:  []byte(`{"success":false,"error":"not found"}`),
+			wantErrStr: "user metadata not found",
+		},
+		{
+			name:       "malformed JSON returns parse error",
+			replyData:  []byte(`not-json`),
+			wantErrStr: "failed to parse user_metadata response",
+		},
+		{
+			name:       "transport error is returned",
+			replyErr:   fmt.Errorf("nats: timeout"),
+			wantErrStr: "nats: timeout",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockConn := &MockNATSConn{}
+			mockConn.On("RequestMsgWithContext", mock.Anything, mock.MatchedBy(func(msg *natsgo.Msg) bool {
+				return msg.Subject == constants.AuthUserMetadataReadSubject
+			})).Return(replyMsg(tt.replyData), tt.replyErr)
+
+			reader := &UserReaderNATS{NatsConn: mockConn}
+			got, err := reader.UserMetadataByPrincipal(context.Background(), "alice")
+
+			if tt.wantErrStr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrStr)
+				assert.Nil(t, got)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantMeta, got)
+			}
+			mockConn.AssertExpectations(t)
+		})
+	}
+}

--- a/internal/service/project_operations.go
+++ b/internal/service/project_operations.go
@@ -744,12 +744,13 @@ func isCrowdfundingOnly(fundingModels []string) bool {
 	return len(fundingModels) == 1 && fundingModels[0] == "Crowdfunding"
 }
 
-// enrichAllRoleFields overwrites Username on every UserInfo across all supplied slices and singles
-// with the authoritative LFID from the auth service.
+// enrichAllRoleFields overwrites Username, Name, and Avatar on every UserInfo across all supplied
+// slices and singles with authoritative values from the auth service.
 // Each unique email is looked up exactly once; lookups run concurrently with a bounded semaphore.
-// Misses (unknown email, empty email) write an explicit empty-string pointer so the settings
-// converter always overwrites any previously-stored username in the database.
-// Transport errors are returned and the request fails — stale LFIDs are never silently kept.
+// Username misses (unknown email, empty email) write an explicit empty-string pointer so the
+// settings converter always overwrites any previously-stored username in the database.
+// Username transport errors fail the request — stale LFIDs must never be silently kept.
+// Metadata (name/avatar) errors only log a warning; display fields do not block the write.
 func (s *ProjectsService) enrichAllRoleFields(
 	ctx context.Context,
 	slices [][]*projsvc.UserInfo,
@@ -794,8 +795,14 @@ func (s *ProjectsService) enrichAllRoleFields(
 		return nil
 	}
 
+	// enrichResult holds the resolved identity and profile for one email address.
+	type enrichResult struct {
+		username string
+		metadata *domain.UserMetadata
+	}
+
 	// Look up each unique email concurrently.
-	results := make(map[string]string, len(byEmail))
+	results := make(map[string]enrichResult, len(byEmail))
 	var mu sync.Mutex
 	const maxConcurrent = 8
 	g, gCtx := errgroup.WithContext(ctx)
@@ -806,18 +813,33 @@ func (s *ProjectsService) enrichAllRoleFields(
 		g.Go(func() error {
 			sem <- struct{}{}
 			defer func() { <-sem }()
+
 			username, err := s.UserReader.UsernameByEmail(gCtx, email)
 			if err != nil {
 				if errors.Is(err, domain.ErrUserNotFound) {
 					mu.Lock()
-					results[email] = ""
+					results[email] = enrichResult{}
 					mu.Unlock()
 					return nil
 				}
 				return err
 			}
+
+			// Username resolved — now fetch authoritative profile data.
+			// Metadata failures are non-fatal: display fields must not block the write.
+			var meta *domain.UserMetadata
+			if username != "" {
+				m, metaErr := s.UserReader.UserMetadataByPrincipal(gCtx, username)
+				if metaErr != nil {
+					slog.WarnContext(gCtx, "user metadata lookup failed; name/avatar will not be enriched",
+						"email", email, "username", username, "error", metaErr)
+				} else {
+					meta = m
+				}
+			}
+
 			mu.Lock()
-			results[email] = username
+			results[email] = enrichResult{username: username, metadata: meta}
 			mu.Unlock()
 			return nil
 		})
@@ -827,11 +849,15 @@ func (s *ProjectsService) enrichAllRoleFields(
 		return err
 	}
 
-	// Apply resolved usernames — empty string clears any previously-stored value.
+	// Apply resolved username, name, and avatar — empty strings clear any previously-stored values.
 	for email, eg := range byEmail {
-		username := results[email]
+		r := results[email]
 		for _, u := range eg.users {
-			u.Username = misc.StringPtr(username)
+			u.Username = misc.StringPtr(r.username)
+			if r.metadata != nil {
+				u.Name = misc.StringPtr(r.metadata.Name)
+				u.Avatar = misc.StringPtr(r.metadata.Picture)
+			}
 		}
 	}
 	return nil

--- a/internal/service/project_operations.go
+++ b/internal/service/project_operations.go
@@ -756,6 +756,7 @@ func (s *ProjectsService) enrichAllRoleFields(
 	slices [][]*projsvc.UserInfo,
 	singles []*projsvc.UserInfo,
 ) error {
+	// Guard for incomplete wiring outside the normal ServiceReady path.
 	if s.UserReader == nil {
 		return domain.ErrInternal
 	}
@@ -768,12 +769,16 @@ func (s *ProjectsService) enrichAllRoleFields(
 		if u == nil {
 			return
 		}
-		if u.Email == nil || *u.Email == "" {
+		// Normalize first so a whitespace-only email like "   " doesn't reach the NATS call.
+		if u.Email == nil {
 			u.Username = misc.StringPtr("")
 			return
 		}
-		// Normalize email so Bob@Example.com and bob@example.com share the same lookup.
 		normEmail := strings.ToLower(strings.TrimSpace(*u.Email))
+		if normEmail == "" {
+			u.Username = misc.StringPtr("")
+			return
+		}
 		eg := byEmail[normEmail]
 		if eg == nil {
 			eg = &group{}

--- a/internal/service/project_operations.go
+++ b/internal/service/project_operations.go
@@ -836,7 +836,7 @@ func (s *ProjectsService) enrichAllRoleFields(
 				m, metaErr := s.UserReader.UserMetadataByPrincipal(gCtx, username)
 				if metaErr != nil {
 					slog.WarnContext(gCtx, "user metadata lookup failed; name/avatar will not be enriched",
-						"email", email, "username", username, "error", metaErr)
+						"email", email, "username", username, constants.ErrKey, metaErr)
 				} else {
 					meta = m
 				}
@@ -862,8 +862,14 @@ func (s *ProjectsService) enrichAllRoleFields(
 		for _, u := range eg.users {
 			u.Username = misc.StringPtr(r.username)
 			if r.metadata != nil {
-				u.Name = misc.StringPtr(r.metadata.Name)
-				u.Avatar = misc.StringPtr(r.metadata.Picture)
+				// Only overwrite when the auth service returned a non-empty value so a partial
+				// metadata response doesn't silently erase a previously stored display name/avatar.
+				if r.metadata.Name != "" {
+					u.Name = misc.StringPtr(r.metadata.Name)
+				}
+				if r.metadata.Picture != "" {
+					u.Avatar = misc.StringPtr(r.metadata.Picture)
+				}
 			}
 		}
 	}

--- a/internal/service/project_operations.go
+++ b/internal/service/project_operations.go
@@ -836,7 +836,7 @@ func (s *ProjectsService) enrichAllRoleFields(
 				m, metaErr := s.UserReader.UserMetadataByPrincipal(gCtx, username)
 				if metaErr != nil {
 					slog.WarnContext(gCtx, "user metadata lookup failed; name/avatar will not be enriched",
-						"has_username", username != "", constants.ErrKey, metaErr)
+						constants.ErrKey, metaErr)
 				} else {
 					meta = m
 				}

--- a/internal/service/project_operations.go
+++ b/internal/service/project_operations.go
@@ -836,7 +836,7 @@ func (s *ProjectsService) enrichAllRoleFields(
 				m, metaErr := s.UserReader.UserMetadataByPrincipal(gCtx, username)
 				if metaErr != nil {
 					slog.WarnContext(gCtx, "user metadata lookup failed; name/avatar will not be enriched",
-						"email", email, "username", username, constants.ErrKey, metaErr)
+						"has_username", username != "", constants.ErrKey, metaErr)
 				} else {
 					meta = m
 				}
@@ -853,10 +853,9 @@ func (s *ProjectsService) enrichAllRoleFields(
 		return err
 	}
 
-	// Apply resolved username, name, and avatar — empty strings clear any previously-stored values.
-	// UserMetadata carries additional profile fields (JobTitle, Organization, etc.) that UserInfo
-	// does not currently model; they are fetched now so the domain struct is complete for callers
-	// that may need them in future without requiring a second NATS round-trip.
+	// Apply resolved username, name, and avatar to each UserInfo entry.
+	// Only Name and Avatar are written back; other metadata fields (JobTitle, Organization, etc.)
+	// are not surfaced in UserInfo and are discarded after this call.
 	for email, eg := range byEmail {
 		r := results[email]
 		for _, u := range eg.users {

--- a/internal/service/project_operations.go
+++ b/internal/service/project_operations.go
@@ -814,7 +814,6 @@ func (s *ProjectsService) enrichAllRoleFields(
 	sem := make(chan struct{}, maxConcurrent)
 
 	for email := range byEmail {
-		email := email
 		g.Go(func() error {
 			sem <- struct{}{}
 			defer func() { <-sem }()
@@ -855,6 +854,9 @@ func (s *ProjectsService) enrichAllRoleFields(
 	}
 
 	// Apply resolved username, name, and avatar — empty strings clear any previously-stored values.
+	// UserMetadata carries additional profile fields (JobTitle, Organization, etc.) that UserInfo
+	// does not currently model; they are fetched now so the domain struct is complete for callers
+	// that may need them in future without requiring a second NATS round-trip.
 	for email, eg := range byEmail {
 		r := results[email]
 		for _, u := range eg.users {

--- a/internal/service/project_operations_test.go
+++ b/internal/service/project_operations_test.go
@@ -1120,7 +1120,10 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				mockRepo.On("GetProjectSettings", mock.Anything, "project-uid-1").Return(existingSettings, nil)
 				// Username is enriched; name/avatar keep caller-supplied values when metadata fails.
 				mockRepo.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
-					return len(s.Writers) == 1 && s.Writers[0].Username == "dave-lfid"
+					return len(s.Writers) == 1 &&
+						s.Writers[0].Username == "dave-lfid" &&
+						s.Writers[0].Name == "Dave" && // caller-supplied — not overwritten on metadata failure
+						s.Writers[0].Avatar == "" // caller supplied no avatar — still empty
 				}), uint64(1)).Return(nil)
 				mockRepo.On("GetProjectBase", mock.Anything, "project-uid-1").Return(projectDB, nil)
 				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)

--- a/internal/service/project_operations_test.go
+++ b/internal/service/project_operations_test.go
@@ -232,6 +232,7 @@ func TestProjectsService_CreateProject(t *testing.T) {
 			},
 			setupUserReader: func(mockUserReader *domain.MockUserReader) {
 				mockUserReader.On("UsernameByEmail", mock.Anything, "carol@example.com").Return("carol-lfid", nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "carol-lfid").Return((*domain.UserMetadata)(nil), nil)
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
 				mockRepo.On("ProjectSlugExists", mock.Anything, "new-project").Return(false, nil)
@@ -894,6 +895,7 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 			},
 			setupUserReader: func(mockUserReader *domain.MockUserReader) {
 				mockUserReader.On("UsernameByEmail", mock.Anything, "alice@example.com").Return("alice", nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "alice").Return((*domain.UserMetadata)(nil), nil)
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
 				existingSettings := &models.ProjectSettings{UID: "project-uid-1", CreatedAt: func() *time.Time { t := time.Now(); return &t }()}
@@ -939,6 +941,7 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 			},
 			setupUserReader: func(mockUserReader *domain.MockUserReader) {
 				mockUserReader.On("UsernameByEmail", mock.Anything, "bob@example.com").Return("real-bob", nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "real-bob").Return((*domain.UserMetadata)(nil), nil)
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
 				existingSettings := &models.ProjectSettings{UID: "project-uid-1"}
@@ -1054,6 +1057,70 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				// Username must be "" — the stale "stale-lfid" must not be preserved.
 				mockRepo.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
 					return len(s.Writers) == 1 && s.Writers[0].Username == ""
+				}), uint64(1)).Return(nil)
+				mockRepo.On("GetProjectBase", mock.Anything, "project-uid-1").Return(projectDB, nil)
+				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("SendAccessMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("SendProjectEventMessage", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "metadata enriched from auth service — name and avatar overwritten",
+			payload: &projsvc.UpdateProjectSettingsPayload{
+				UID:     misc.StringPtr("project-uid-1"),
+				IfMatch: misc.StringPtr("1"),
+				Writers: []*projsvc.UserInfo{
+					{Username: misc.StringPtr("caller-name"), Name: misc.StringPtr("Caller Supplied Name"), Email: misc.StringPtr("carol@example.com"), Avatar: misc.StringPtr("http://bad-avatar.example.com")},
+				},
+			},
+			setupUserReader: func(mockUserReader *domain.MockUserReader) {
+				mockUserReader.On("UsernameByEmail", mock.Anything, "carol@example.com").Return("carol-lfid", nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "carol-lfid").Return(&domain.UserMetadata{
+					Name:    "Carol Real Name",
+					Picture: "https://auth.example.com/carol.png",
+				}, nil)
+			},
+			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
+				existingSettings := &models.ProjectSettings{UID: "project-uid-1"}
+				projectDB := &models.ProjectBase{UID: "project-uid-1"}
+				mockRepo.On("ProjectExists", mock.Anything, "project-uid-1").Return(true, nil)
+				mockRepo.On("GetProjectSettings", mock.Anything, "project-uid-1").Return(existingSettings, nil)
+				// Username, name, and avatar must all come from auth service, not the caller.
+				mockRepo.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
+					return len(s.Writers) == 1 &&
+						s.Writers[0].Username == "carol-lfid" &&
+						s.Writers[0].Name == "Carol Real Name" &&
+						s.Writers[0].Avatar == "https://auth.example.com/carol.png"
+				}), uint64(1)).Return(nil)
+				mockRepo.On("GetProjectBase", mock.Anything, "project-uid-1").Return(projectDB, nil)
+				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("SendAccessMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("SendProjectEventMessage", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "metadata lookup fails — request still succeeds, name/avatar unchanged",
+			payload: &projsvc.UpdateProjectSettingsPayload{
+				UID:     misc.StringPtr("project-uid-1"),
+				IfMatch: misc.StringPtr("1"),
+				Writers: []*projsvc.UserInfo{
+					{Name: misc.StringPtr("Dave"), Email: misc.StringPtr("dave@example.com")},
+				},
+			},
+			setupUserReader: func(mockUserReader *domain.MockUserReader) {
+				mockUserReader.On("UsernameByEmail", mock.Anything, "dave@example.com").Return("dave-lfid", nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "dave-lfid").Return((*domain.UserMetadata)(nil), assert.AnError)
+			},
+			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
+				existingSettings := &models.ProjectSettings{UID: "project-uid-1"}
+				projectDB := &models.ProjectBase{UID: "project-uid-1"}
+				mockRepo.On("ProjectExists", mock.Anything, "project-uid-1").Return(true, nil)
+				mockRepo.On("GetProjectSettings", mock.Anything, "project-uid-1").Return(existingSettings, nil)
+				// Username is enriched; name/avatar keep caller-supplied values when metadata fails.
+				mockRepo.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
+					return len(s.Writers) == 1 && s.Writers[0].Username == "dave-lfid"
 				}), uint64(1)).Return(nil)
 				mockRepo.On("GetProjectBase", mock.Anything, "project-uid-1").Return(projectDB, nil)
 				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)


### PR DESCRIPTION
## Summary

- Expands `domain.UserMetadata` to carry all fields the auth service exposes: `Picture`, `Zoneinfo`, `Name`, `GivenName`, `FamilyName`, `JobTitle`, `Organization`, `Country`, `StateProvince`, `City`, `Address`, `PostalCode`, `PhoneNumber`, `TShirtSize`
- Updates the NATS decoder in `UserReaderNATS.UserMetadataByPrincipal` to map all new fields from the auth-service JSON response
- Extends `enrichAllRoleFields` to pipeline a `UserMetadataByPrincipal` call after a successful LFID lookup and overwrite `Name` and `Avatar` on each `UserInfo` with authoritative values from the auth service — caller-supplied name/avatar are untrusted for the same reason caller-supplied username is untrusted
- Metadata fetch failures are non-fatal (log warning, continue) — display fields must not block the access-control write; username transport errors still fail the request
- Addresses all unresolved review comments from PR #71: whitespace-only email normalization, nil guard comment, JSON success-envelope guard in `UsernameByEmail`, and new `user_reader_test.go` with 13 test cases covering `UsernameByEmail` and `UserMetadataByPrincipal`

## Ticket

[LFXV2-1961](https://linuxfoundation.atlassian.net/browse/LFXV2-1961)

## Test plan

- [x] `make test` — all unit tests pass
- [x] `metadata enriched from auth service — name and avatar overwritten` test case verifies caller-supplied name/avatar are replaced with auth-service values
- [x] `metadata lookup fails — request still succeeds, name/avatar unchanged` test case verifies non-fatal metadata failure path
- [x] `user_reader_test.go` — `UsernameByEmail` and `UserMetadataByPrincipal` covered at the NATS infrastructure layer (plain-text success, trimming, empty body, JSON error/success envelopes, transport error, all metadata fields, partial fields)
- [x] End-to-end: send `PUT /projects/{uid}/settings` with a writer whose email maps to a known LFID; confirm persisted KV entry (`nats kv get project-settings`) shows auth-service name and avatar, not the caller-supplied values

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1961]: https://linuxfoundation.atlassian.net/browse/LFXV2-1961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ