### PR TITLE
fix(LFXV2-1992): use email_to_sub to store subject identifier for project members

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ build/
 *.dll
 *.so
 *.dylib
-project-api
+/project-api
 
 # ==============================================================================
 # Go specific files

--- a/cmd/project-api/service_endpoint_project_test.go
+++ b/cmd/project-api/service_endpoint_project_test.go
@@ -152,14 +152,14 @@ func TestCreateProject(t *testing.T) {
 				},
 			},
 			setupUserReader: func(mockUserReader *domain.MockUserReader) {
-				mockUserReader.On("UsernameByEmail", mock.Anything, "user1@example.com").Return("user1", nil)
-				mockUserReader.On("UsernameByEmail", mock.Anything, "user2@example.com").Return("user2", nil)
-				mockUserReader.On("UsernameByEmail", mock.Anything, "user3@example.com").Return("user3", nil)
-				mockUserReader.On("UsernameByEmail", mock.Anything, "user4@example.com").Return("user4", nil)
-				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "user1").Return((*domain.UserMetadata)(nil), nil)
-				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "user2").Return((*domain.UserMetadata)(nil), nil)
-				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "user3").Return((*domain.UserMetadata)(nil), nil)
-				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "user4").Return((*domain.UserMetadata)(nil), nil)
+				mockUserReader.On("SubByEmail", mock.Anything, "user1@example.com").Return("auth0|user1", nil)
+				mockUserReader.On("SubByEmail", mock.Anything, "user2@example.com").Return("auth0|user2", nil)
+				mockUserReader.On("SubByEmail", mock.Anything, "user3@example.com").Return("auth0|user3", nil)
+				mockUserReader.On("SubByEmail", mock.Anything, "user4@example.com").Return("auth0|user4", nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "auth0|user1").Return((*domain.UserMetadata)(nil), nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "auth0|user2").Return((*domain.UserMetadata)(nil), nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "auth0|user3").Return((*domain.UserMetadata)(nil), nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "auth0|user4").Return((*domain.UserMetadata)(nil), nil)
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockMsg *domain.MockMessageBuilder) {
 				// Mock parent project exists (for ParentUID validation)
@@ -169,8 +169,8 @@ func TestCreateProject(t *testing.T) {
 				// Mock successful project creation — MatchedBy validates enriched LFIDs were persisted.
 				mockRepo.On("CreateProject", mock.Anything, mock.AnythingOfType("*models.ProjectBase"),
 					mock.MatchedBy(func(s *models.ProjectSettings) bool {
-						return len(s.Writers) == 2 && s.Writers[0].Username == "user1" && s.Writers[1].Username == "user2" &&
-							len(s.Auditors) == 2 && s.Auditors[0].Username == "user3" && s.Auditors[1].Username == "user4"
+						return len(s.Writers) == 2 && s.Writers[0].Username == "auth0|user1" && s.Writers[1].Username == "auth0|user2" &&
+							len(s.Auditors) == 2 && s.Auditors[0].Username == "auth0|user3" && s.Auditors[1].Username == "auth0|user4"
 					})).Return(nil)
 				// Mock message sending
 				mockMsg.On("SendIndexerMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.IndexerMessageEnvelope"), mock.AnythingOfType("bool")).Return(nil).Times(2)

--- a/internal/domain/mock.go
+++ b/internal/domain/mock.go
@@ -293,7 +293,7 @@ func (m *MockUserReader) UserMetadataByPrincipal(ctx context.Context, principal 
 	return args.Get(0).(*UserMetadata), args.Error(1)
 }
 
-func (m *MockUserReader) UsernameByEmail(ctx context.Context, email string) (string, error) {
+func (m *MockUserReader) SubByEmail(ctx context.Context, email string) (string, error) {
 	args := m.Called(ctx, email)
 	return args.String(0), args.Error(1)
 }

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -27,7 +27,7 @@ type UserMetadata struct {
 type UserReader interface {
 	// UserMetadataByPrincipal retrieves profile metadata for a user by their principal.
 	UserMetadataByPrincipal(ctx context.Context, principal string) (*UserMetadata, error)
-	// UsernameByEmail resolves the registered LFID username for the given primary email address.
+	// SubByEmail resolves the subject identifier for the given primary email address.
 	// Returns ErrUserNotFound when no user is registered with that email.
-	UsernameByEmail(ctx context.Context, email string) (string, error)
+	SubByEmail(ctx context.Context, email string) (string, error)
 }

--- a/internal/infrastructure/nats/user_reader.go
+++ b/internal/infrastructure/nats/user_reader.go
@@ -122,19 +122,19 @@ func (u *UserReaderNATS) SubByEmail(ctx context.Context, email string) (string, 
 		Data:    []byte(email),
 	})
 	if err != nil {
-		return "", fmt.Errorf("email_to_username request failed: %w", err)
+		return "", fmt.Errorf("email_to_sub request failed: %w", err)
 	}
 
-	// The auth service sends a plain-text username on success and a JSON error envelope on miss.
+	// The auth service sends a plain-text subject on success and a JSON error envelope on miss.
 	// Trim leading/trailing whitespace before inspection so intermediaries that add a trailing
-	// newline or leading space don't corrupt the username or bypass JSON detection.
+	// newline or leading space don't corrupt the subject or bypass JSON detection.
 	body := strings.TrimSpace(string(reply.Data))
 	if body == "" {
 		return "", domain.ErrUserNotFound
 	}
 
 	// Any object-shaped response (starts with '{') is an error envelope or contract violation.
-	// Never return JSON as a username — it would propagate garbage into access control.
+	// Never return JSON as a subject — it would propagate garbage into access control.
 	// This covers both well-formed error envelopes and malformed JSON blobs.
 	if body[0] == '{' {
 		return "", domain.ErrUserNotFound

--- a/internal/infrastructure/nats/user_reader.go
+++ b/internal/infrastructure/nats/user_reader.go
@@ -114,11 +114,11 @@ func (u *UserReaderNATS) UserMetadataByPrincipal(ctx context.Context, principal 
 	return result, nil
 }
 
-// UsernameByEmail resolves the registered LFID username for the given primary email address.
-// The auth service replies with a plain-text username on success, or a JSON error envelope on miss.
-func (u *UserReaderNATS) UsernameByEmail(ctx context.Context, email string) (string, error) {
+// SubByEmail resolves the subject identifier for the given primary email address.
+// The auth service replies with a plain-text subject on success, or a JSON error envelope on miss.
+func (u *UserReaderNATS) SubByEmail(ctx context.Context, email string) (string, error) {
 	reply, err := u.NatsConn.RequestMsgWithContext(ctx, &natsgo.Msg{
-		Subject: constants.AuthEmailToUsernameSubject,
+		Subject: constants.AuthEmailToSubSubject,
 		Data:    []byte(email),
 	})
 	if err != nil {

--- a/internal/infrastructure/nats/user_reader.go
+++ b/internal/infrastructure/nats/user_reader.go
@@ -139,13 +139,16 @@ func (u *UserReaderNATS) SubByEmail(ctx context.Context, email string) (string, 
 	// ErrUserNotFound as "member disappeared".
 	if body[0] == '{' {
 		var envelope struct {
-			Success bool   `json:"success"`
+			Success *bool  `json:"success"`
 			Error   string `json:"error,omitempty"`
 		}
 		if err := json.Unmarshal(reply.Data, &envelope); err != nil {
 			return "", fmt.Errorf("failed to parse email_to_sub response: %w", err)
 		}
-		if !envelope.Success {
+		if envelope.Success == nil {
+			return "", fmt.Errorf("email_to_sub response missing success field")
+		}
+		if !*envelope.Success {
 			return "", domain.ErrUserNotFound
 		}
 		return "", fmt.Errorf("unexpected email_to_sub success envelope")

--- a/internal/infrastructure/nats/user_reader.go
+++ b/internal/infrastructure/nats/user_reader.go
@@ -133,11 +133,22 @@ func (u *UserReaderNATS) SubByEmail(ctx context.Context, email string) (string, 
 		return "", domain.ErrUserNotFound
 	}
 
-	// Any object-shaped response (starts with '{') is an error envelope or contract violation.
-	// Never return JSON as a subject — it would propagate garbage into access control.
-	// This covers both well-formed error envelopes and malformed JSON blobs.
+	// Any object-shaped response is an envelope — parse it to distinguish an explicit
+	// not-found from a malformed or unexpected reply. Returning ErrUserNotFound for
+	// non-404 cases would silently clear stored principals in callers that treat
+	// ErrUserNotFound as "member disappeared".
 	if body[0] == '{' {
-		return "", domain.ErrUserNotFound
+		var envelope struct {
+			Success bool   `json:"success"`
+			Error   string `json:"error,omitempty"`
+		}
+		if err := json.Unmarshal(reply.Data, &envelope); err != nil {
+			return "", fmt.Errorf("failed to parse email_to_sub response: %w", err)
+		}
+		if !envelope.Success {
+			return "", domain.ErrUserNotFound
+		}
+		return "", fmt.Errorf("unexpected email_to_sub success envelope")
 	}
 
 	return body, nil

--- a/internal/infrastructure/nats/user_reader_test.go
+++ b/internal/infrastructure/nats/user_reader_test.go
@@ -33,12 +33,17 @@ func TestUserReaderNATS_SubByEmail(t *testing.T) {
 		wantErrStr string
 	}{
 		{
-			name:     "plain-text username returned on success",
+			name:     "plain-text subject returned on success",
 			reply:    replyMsg([]byte("alice")),
 			wantUser: "alice",
 		},
 		{
-			name:     "trailing newline trimmed from username",
+			name:     "provider-qualified sub preserved without truncation",
+			reply:    replyMsg([]byte("auth0|alice")),
+			wantUser: "auth0|alice",
+		},
+		{
+			name:     "trailing newline trimmed from subject",
 			reply:    replyMsg([]byte("alice\n")),
 			wantUser: "alice",
 		},
@@ -63,14 +68,14 @@ func TestUserReaderNATS_SubByEmail(t *testing.T) {
 			wantErr: domain.ErrUserNotFound,
 		},
 		{
-			name:    "JSON success envelope returns ErrUserNotFound instead of leaking JSON as username",
-			reply:   replyMsg([]byte(`{"success":true,"username":"alice"}`)),
-			wantErr: domain.ErrUserNotFound,
+			name:       "JSON success envelope returns error instead of leaking JSON as subject",
+			reply:      replyMsg([]byte(`{"success":true,"username":"alice"}`)),
+			wantErrStr: "unexpected email_to_sub success envelope",
 		},
 		{
-			name:    "malformed JSON object returns ErrUserNotFound instead of leaking raw body as username",
-			reply:   replyMsg([]byte(`{"success":"true"}`)),
-			wantErr: domain.ErrUserNotFound,
+			name:       "malformed JSON object returns parse error instead of leaking raw body as subject",
+			reply:      replyMsg([]byte(`{"success":"true"}`)),
+			wantErrStr: "failed to parse email_to_sub response",
 		},
 		{
 			name:       "transport error is wrapped and returned",

--- a/internal/infrastructure/nats/user_reader_test.go
+++ b/internal/infrastructure/nats/user_reader_test.go
@@ -68,6 +68,11 @@ func TestUserReaderNATS_SubByEmail(t *testing.T) {
 			wantErr: domain.ErrUserNotFound,
 		},
 		{
+			name:       "JSON envelope missing success field returns descriptive error",
+			reply:      replyMsg([]byte(`{"error":"something unexpected"}`)),
+			wantErrStr: "email_to_sub response missing success field",
+		},
+		{
 			name:       "JSON success envelope returns error instead of leaking JSON as subject",
 			reply:      replyMsg([]byte(`{"success":true,"username":"alice"}`)),
 			wantErrStr: "unexpected email_to_sub success envelope",

--- a/internal/infrastructure/nats/user_reader_test.go
+++ b/internal/infrastructure/nats/user_reader_test.go
@@ -23,7 +23,7 @@ import (
 // Transport-error cases should pass nil as the reply directly.
 func replyMsg(data []byte) *natsgo.Msg { return &natsgo.Msg{Data: data} }
 
-func TestUserReaderNATS_UsernameByEmail(t *testing.T) {
+func TestUserReaderNATS_SubByEmail(t *testing.T) {
 	tests := []struct {
 		name       string
 		reply      *natsgo.Msg // nil simulates a transport error
@@ -76,7 +76,7 @@ func TestUserReaderNATS_UsernameByEmail(t *testing.T) {
 			name:       "transport error is wrapped and returned",
 			reply:      nil,
 			replyErr:   errors.New("nats: connection closed"),
-			wantErrStr: "email_to_username request failed",
+			wantErrStr: "email_to_sub request failed",
 		},
 	}
 

--- a/internal/infrastructure/nats/user_reader_test.go
+++ b/internal/infrastructure/nats/user_reader_test.go
@@ -84,11 +84,11 @@ func TestUserReaderNATS_UsernameByEmail(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockConn := &MockNATSConn{}
 			mockConn.On("RequestMsgWithContext", mock.Anything, mock.MatchedBy(func(msg *natsgo.Msg) bool {
-				return msg.Subject == constants.AuthEmailToUsernameSubject
+				return msg.Subject == constants.AuthEmailToSubSubject
 			})).Return(tt.reply, tt.replyErr)
 
 			reader := &UserReaderNATS{NatsConn: mockConn}
-			got, err := reader.UsernameByEmail(context.Background(), "test@example.com")
+			got, err := reader.SubByEmail(context.Background(), "test@example.com")
 
 			switch {
 			case tt.wantErr != nil:

--- a/internal/service/project_operations.go
+++ b/internal/service/project_operations.go
@@ -818,6 +818,9 @@ func (s *ProjectsService) enrichAllRoleFields(
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
+			// username holds the auth subject identifier returned by SubByEmail. The field
+			// is named "username" because ProjectSettings stores it under that key —
+			// renaming requires a coordinated data migration with fga-sync.
 			username, err := s.UserReader.SubByEmail(gCtx, email)
 			if err != nil {
 				if errors.Is(err, domain.ErrUserNotFound) {
@@ -829,7 +832,7 @@ func (s *ProjectsService) enrichAllRoleFields(
 				return err
 			}
 
-			// Username resolved — now fetch authoritative profile data.
+			// Subject resolved — now fetch authoritative profile data.
 			// Metadata failures are non-fatal: display fields must not block the write.
 			var meta *domain.UserMetadata
 			if username != "" {

--- a/internal/service/project_operations.go
+++ b/internal/service/project_operations.go
@@ -818,7 +818,7 @@ func (s *ProjectsService) enrichAllRoleFields(
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			username, err := s.UserReader.UsernameByEmail(gCtx, email)
+			username, err := s.UserReader.SubByEmail(gCtx, email)
 			if err != nil {
 				if errors.Is(err, domain.ErrUserNotFound) {
 					mu.Lock()

--- a/internal/service/project_operations_test.go
+++ b/internal/service/project_operations_test.go
@@ -239,7 +239,7 @@ func TestProjectsService_CreateProject(t *testing.T) {
 				mockRepo.On("CreateProject", mock.Anything, mock.AnythingOfType("*models.ProjectBase"), mock.MatchedBy(func(s *models.ProjectSettings) bool {
 					return len(s.Writers) == 1 && s.Writers[0].Username == "auth0|carol-lfid"
 				})).Return(nil)
-				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(2)
 				mockBuilder.On("SendAccessMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: false,

--- a/internal/service/project_operations_test.go
+++ b/internal/service/project_operations_test.go
@@ -231,13 +231,13 @@ func TestProjectsService_CreateProject(t *testing.T) {
 				},
 			},
 			setupUserReader: func(mockUserReader *domain.MockUserReader) {
-				mockUserReader.On("UsernameByEmail", mock.Anything, "carol@example.com").Return("carol-lfid", nil)
-				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "carol-lfid").Return((*domain.UserMetadata)(nil), nil)
+				mockUserReader.On("SubByEmail", mock.Anything, "carol@example.com").Return("auth0|carol-lfid", nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "auth0|carol-lfid").Return((*domain.UserMetadata)(nil), nil)
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
 				mockRepo.On("ProjectSlugExists", mock.Anything, "new-project").Return(false, nil)
 				mockRepo.On("CreateProject", mock.Anything, mock.AnythingOfType("*models.ProjectBase"), mock.MatchedBy(func(s *models.ProjectSettings) bool {
-					return len(s.Writers) == 1 && s.Writers[0].Username == "carol-lfid"
+					return len(s.Writers) == 1 && s.Writers[0].Username == "auth0|carol-lfid"
 				})).Return(nil)
 				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(2)
 				mockBuilder.On("SendAccessMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -894,14 +894,14 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				},
 			},
 			setupUserReader: func(mockUserReader *domain.MockUserReader) {
-				mockUserReader.On("UsernameByEmail", mock.Anything, "alice@example.com").Return("alice", nil)
-				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "alice").Return((*domain.UserMetadata)(nil), nil)
+				mockUserReader.On("SubByEmail", mock.Anything, "alice@example.com").Return("auth0|alice", nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "auth0|alice").Return((*domain.UserMetadata)(nil), nil)
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
 				existingSettings := &models.ProjectSettings{UID: "project-uid-1", CreatedAt: func() *time.Time { t := time.Now(); return &t }()}
 				updatedSettings := &models.ProjectSettings{
 					UID:     "project-uid-1",
-					Writers: []models.UserInfo{{Username: "alice", Name: "Alice", Email: "alice@example.com"}},
+					Writers: []models.UserInfo{{Username: "auth0|alice", Name: "Alice", Email: "alice@example.com"}},
 				}
 				projectDB := &models.ProjectBase{UID: "project-uid-1", Public: true}
 
@@ -940,8 +940,8 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				},
 			},
 			setupUserReader: func(mockUserReader *domain.MockUserReader) {
-				mockUserReader.On("UsernameByEmail", mock.Anything, "bob@example.com").Return("real-bob", nil)
-				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "real-bob").Return((*domain.UserMetadata)(nil), nil)
+				mockUserReader.On("SubByEmail", mock.Anything, "bob@example.com").Return("auth0|real-bob", nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "auth0|real-bob").Return((*domain.UserMetadata)(nil), nil)
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
 				existingSettings := &models.ProjectSettings{UID: "project-uid-1"}
@@ -949,7 +949,7 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				mockRepo.On("ProjectExists", mock.Anything, "project-uid-1").Return(true, nil)
 				mockRepo.On("GetProjectSettings", mock.Anything, "project-uid-1").Return(existingSettings, nil)
 				mockRepo.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
-					return len(s.Writers) == 1 && s.Writers[0].Username == "real-bob"
+					return len(s.Writers) == 1 && s.Writers[0].Username == "auth0|real-bob"
 				}), uint64(1)).Return(nil)
 				mockRepo.On("GetProjectBase", mock.Anything, "project-uid-1").Return(projectDB, nil)
 				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -968,7 +968,7 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				},
 			},
 			setupUserReader: func(mockUserReader *domain.MockUserReader) {
-				mockUserReader.On("UsernameByEmail", mock.Anything, "nobody@example.com").Return("", domain.ErrUserNotFound)
+				mockUserReader.On("SubByEmail", mock.Anything, "nobody@example.com").Return("", domain.ErrUserNotFound)
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
 				existingSettings := &models.ProjectSettings{UID: "project-uid-1"}
@@ -1019,7 +1019,7 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				},
 			},
 			setupUserReader: func(mockUserReader *domain.MockUserReader) {
-				mockUserReader.On("UsernameByEmail", mock.Anything, "eve@example.com").Return("", assert.AnError)
+				mockUserReader.On("SubByEmail", mock.Anything, "eve@example.com").Return("", assert.AnError)
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
 				existingSettings := &models.ProjectSettings{UID: "project-uid-1"}
@@ -1041,7 +1041,7 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				},
 			},
 			setupUserReader: func(mockUserReader *domain.MockUserReader) {
-				mockUserReader.On("UsernameByEmail", mock.Anything, "gone@example.com").Return("", domain.ErrUserNotFound)
+				mockUserReader.On("SubByEmail", mock.Anything, "gone@example.com").Return("", domain.ErrUserNotFound)
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
 				// Existing settings already have a writer with the same email and a stored LFID.
@@ -1075,8 +1075,8 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				},
 			},
 			setupUserReader: func(mockUserReader *domain.MockUserReader) {
-				mockUserReader.On("UsernameByEmail", mock.Anything, "carol@example.com").Return("carol-lfid", nil)
-				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "carol-lfid").Return(&domain.UserMetadata{
+				mockUserReader.On("SubByEmail", mock.Anything, "carol@example.com").Return("auth0|carol-lfid", nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "auth0|carol-lfid").Return(&domain.UserMetadata{
 					Name:    "Carol Real Name",
 					Picture: "https://auth.example.com/carol.png",
 				}, nil)
@@ -1089,7 +1089,7 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				// Username, name, and avatar must all come from auth service, not the caller.
 				mockRepo.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
 					return len(s.Writers) == 1 &&
-						s.Writers[0].Username == "carol-lfid" &&
+						s.Writers[0].Username == "auth0|carol-lfid" &&
 						s.Writers[0].Name == "Carol Real Name" &&
 						s.Writers[0].Avatar == "https://auth.example.com/carol.png"
 				}), uint64(1)).Return(nil)
@@ -1110,8 +1110,8 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				},
 			},
 			setupUserReader: func(mockUserReader *domain.MockUserReader) {
-				mockUserReader.On("UsernameByEmail", mock.Anything, "dave@example.com").Return("dave-lfid", nil)
-				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "dave-lfid").Return((*domain.UserMetadata)(nil), assert.AnError)
+				mockUserReader.On("SubByEmail", mock.Anything, "dave@example.com").Return("auth0|dave-lfid", nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "auth0|dave-lfid").Return((*domain.UserMetadata)(nil), assert.AnError)
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
 				existingSettings := &models.ProjectSettings{UID: "project-uid-1"}
@@ -1121,7 +1121,7 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				// Username is enriched; name/avatar keep caller-supplied values when metadata fails.
 				mockRepo.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
 					return len(s.Writers) == 1 &&
-						s.Writers[0].Username == "dave-lfid" &&
+						s.Writers[0].Username == "auth0|dave-lfid" &&
 						s.Writers[0].Name == "Dave" && // caller-supplied — not overwritten on metadata failure
 						s.Writers[0].Avatar == "" // caller supplied no avatar — still empty
 				}), uint64(1)).Return(nil)

--- a/internal/service/project_operations_test.go
+++ b/internal/service/project_operations_test.go
@@ -239,7 +239,7 @@ func TestProjectsService_CreateProject(t *testing.T) {
 				mockRepo.On("CreateProject", mock.Anything, mock.AnythingOfType("*models.ProjectBase"), mock.MatchedBy(func(s *models.ProjectSettings) bool {
 					return len(s.Writers) == 1 && s.Writers[0].Username == "auth0|carol-lfid"
 				})).Return(nil)
-				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(2)
+				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 				mockBuilder.On("SendAccessMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: false,

--- a/pkg/constants/nats.go
+++ b/pkg/constants/nats.go
@@ -96,7 +96,7 @@ const (
 	// The subject is of the form: lfx.auth-service.user_metadata.read
 	AuthUserMetadataReadSubject = "lfx.auth-service.user_metadata.read"
 
-	// AuthEmailToUsernameSubject resolves a registered LFID username by primary email.
-	// Request: plain-text email. Reply: plain-text username on success, JSON error envelope on miss.
-	AuthEmailToUsernameSubject = "lfx.auth-service.email_to_username"
+	// AuthEmailToSubSubject resolves a subject identifier (e.g. auth0|jmedev) by primary email.
+	// Request: plain-text email. Reply: plain-text subject on success, JSON error envelope on miss.
+	AuthEmailToSubSubject = "lfx.auth-service.email_to_sub"
 )


### PR DESCRIPTION
## Summary
- Replaces `email_to_username` with `email_to_sub` when enriching member usernames on project settings create/update
- The previous approach stored plain LFID handles (e.g. `jmedev`), causing fga-sync to write `user:jmedev` tuples that never matched access checks for `user:auth0|jmedev`
- The sub returned by `email_to_sub` is now used for both the stored username and the `UserMetadataByPrincipal` lookup

Closes LFXV2-1992

🤖 Generated with [Claude Code](https://claude.ai/claude-code)