### PR TITLE
[LFXV2-1737] feat(otel): instrument outbound HTTP clients

### DIFF
--- a/internal/infrastructure/auth/jwt.go
+++ b/internal/infrastructure/auth/jwt.go
@@ -7,17 +7,16 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
-	"net/http"
-
 	"github.com/auth0/go-jwt-middleware/v2/jwks"
 	"github.com/auth0/go-jwt-middleware/v2/validator"
 	"github.com/linuxfoundation/lfx-v2-project-service/internal/domain"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"github.com/linuxfoundation/lfx-v2-project-service/pkg/constants"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 const (
@@ -26,6 +25,7 @@ const (
 	defaultIssuer      = "heimdall"
 	defaultAudience    = "lfx-v2-project-service"
 	defaultJWKSURL     = "http://heimdall:4457/.well-known/jwks"
+	jwksClientTimeout  = 10 * time.Second
 )
 
 // JWTAuthConfig holds the configuration parameters for JWT authentication.
@@ -93,7 +93,10 @@ func NewJWTAuth(config JWTAuthConfig) (*JWTAuth, error) {
 		slog.Error("unexpected URL parsing of default issuer", constants.ErrKey, err)
 		return nil, err
 	}
-	otelClient := &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+	otelClient := &http.Client{
+		Transport: otelhttp.NewTransport(http.DefaultTransport),
+		Timeout:   jwksClientTimeout,
+	}
 	provider := jwks.NewCachingProvider(issuer, 5*time.Minute, jwks.WithCustomJWKSURI(jwksURL), jwks.WithCustomClient(otelClient))
 
 	// Set up the JWT validator.

--- a/internal/infrastructure/auth/jwt.go
+++ b/internal/infrastructure/auth/jwt.go
@@ -11,9 +11,12 @@ import (
 	"strings"
 	"time"
 
+	"net/http"
+
 	"github.com/auth0/go-jwt-middleware/v2/jwks"
 	"github.com/auth0/go-jwt-middleware/v2/validator"
 	"github.com/linuxfoundation/lfx-v2-project-service/internal/domain"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"github.com/linuxfoundation/lfx-v2-project-service/pkg/constants"
 )
 
@@ -90,7 +93,8 @@ func NewJWTAuth(config JWTAuthConfig) (*JWTAuth, error) {
 		slog.Error("unexpected URL parsing of default issuer", constants.ErrKey, err)
 		return nil, err
 	}
-	provider := jwks.NewCachingProvider(issuer, 5*time.Minute, jwks.WithCustomJWKSURI(jwksURL))
+	otelClient := &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+	provider := jwks.NewCachingProvider(issuer, 5*time.Minute, jwks.WithCustomJWKSURI(jwksURL), jwks.WithCustomClient(otelClient))
 
 	// Set up the JWT validator.
 	jwtValidator, err := validator.New(


### PR DESCRIPTION
## Summary

Part of [LFXV2-1737](https://linuxfoundation.atlassian.net/browse/LFXV2-1737).

- Wraps the JWKS HTTP client with `otelhttp.NewTransport` so Heimdall key-fetch requests appear as child spans in distributed traces
- Adds a `jwksClientTimeout` (10s) constant to bound JWKS fetch time and prevent indefinite hangs
- Fixes stdlib import grouping (`net/http` moved into stdlib group per `goimports`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1737]: https://linuxfoundation.atlassian.net/browse/LFXV2-1737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ