### PR TITLE
feat: add EMAILS_ENABLED and INVITES_ENABLED feature flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,6 +268,8 @@ func TestEndpoint(t *testing.T) {
 | `AUDIENCE` | JWT audience | lfx-v2-project-service | No |
 | `JWT_AUTH_DISABLED_MOCK_LOCAL_PRINCIPAL` | Mock auth for local dev | - | No |
 | `LFX_SELF_SERVE_BASE_URL` | Base URL for project links in notification emails | derived from `LFX_ENVIRONMENT` | No |
+| `EMAILS_ENABLED` | Gate for outbound role-notification emails to LFID users (`true` to enable) | false | No |
+| `INVITES_ENABLED` | Gate for outbound invite requests to non-LFID users (`true` to enable) | false | No |
 
 ## Authorization (OpenFGA)
 

--- a/charts/lfx-v2-project-service/templates/deployment.yaml
+++ b/charts/lfx-v2-project-service/templates/deployment.yaml
@@ -45,6 +45,10 @@ spec:
               value: {{ .Values.app.audience }}
             - name: SKIP_ETAG_VALIDATION
               value: {{ .Values.app.skipEtagValidation | quote }}
+            - name: EMAILS_ENABLED
+              value: {{ .Values.app.emailsEnabled | quote }}
+            - name: INVITES_ENABLED
+              value: {{ .Values.app.invitesEnabled | quote }}
             - name: JWT_AUTH_DISABLED_MOCK_LOCAL_PRINCIPAL
               value: {{ .Values.app.jwtAuthDisabledMockLocalPrincipal }}
             {{- with .Values.app.extraEnv }}

--- a/charts/lfx-v2-project-service/values.yaml
+++ b/charts/lfx-v2-project-service/values.yaml
@@ -63,6 +63,12 @@ app:
   # skipEtagValidation is a boolean to determine if the etag validation should be skipped
   # (only use for local development)
   skipEtagValidation: false
+  # emailsEnabled gates outbound role-notification emails to LFID users via the email service.
+  # Disabled by default; set to true in environments where email sending should be active.
+  emailsEnabled: false
+  # invitesEnabled gates outbound invite requests for non-LFID users via the invite service.
+  # Disabled by default; set to true in environments where invite sending should be active.
+  invitesEnabled: false
   # jwtAuthDisabledMockLocalPrincipal mocks auth for local development to use a set principal
   # (only use for local development)
   jwtAuthDisabledMockLocalPrincipal: ""

--- a/cmd/project-api/main.go
+++ b/cmd/project-api/main.go
@@ -98,6 +98,8 @@ func main() {
 	service := service.NewProjectsService(jwtAuth, service.ServiceConfig{
 		SkipEtagValidation:  env.SkipEtagValidation,
 		LFXSelfServeBaseURL: env.LFXSelfServeBaseURL,
+		EmailsEnabled:       env.EmailsEnabled,
+		InvitesEnabled:      env.InvitesEnabled,
 	})
 	svc := NewProjectsAPI(service)
 
@@ -163,6 +165,8 @@ type environment struct {
 	Port                string
 	SkipEtagValidation  bool
 	LFXSelfServeBaseURL string
+	EmailsEnabled       bool
+	InvitesEnabled      bool
 }
 
 func parseEnv() environment {
@@ -195,6 +199,8 @@ func parseEnv() environment {
 		Port:                port,
 		SkipEtagValidation:  skipEtagValidation,
 		LFXSelfServeBaseURL: lfxSelfServeBaseURL,
+		EmailsEnabled:       os.Getenv("EMAILS_ENABLED") == "true",
+		InvitesEnabled:      os.Getenv("INVITES_ENABLED") == "true",
 	}
 }
 

--- a/internal/service/project_service.go
+++ b/internal/service/project_service.go
@@ -40,4 +40,10 @@ type ServiceConfig struct {
 	SkipEtagValidation bool
 	// LFXSelfServeBaseURL is the base URL for LFX Self-Serve, used to build project URLs in notification emails.
 	LFXSelfServeBaseURL string
+	// EmailsEnabled gates outbound role-notification emails to LFID users via the email service.
+	// Disabled by default; set EMAILS_ENABLED=true to enable.
+	EmailsEnabled bool
+	// InvitesEnabled gates outbound invite requests for non-LFID users via the invite service.
+	// Disabled by default; set INVITES_ENABLED=true to enable.
+	InvitesEnabled bool
 }

--- a/internal/service/project_subscriber.go
+++ b/internal/service/project_subscriber.go
@@ -130,6 +130,11 @@ func (s *ProjectsService) HandleProjectSettingsUpdated(ctx context.Context, msg 
 
 // handleLFIDChange sends the appropriate email for a user who has an LFID.
 func (s *ProjectsService) handleLFIDChange(ctx context.Context, projectUID, projectName string, change userChange, recipientName, inviterName, projectURL string) error {
+	if !s.Config.EmailsEnabled {
+		slog.DebugContext(ctx, "project_subscriber: skipping email — EMAILS_ENABLED is false",
+			"project_uid", projectUID, "change_kind", change.Kind)
+		return nil
+	}
 	switch change.Kind {
 	case changeAdded:
 		return s.sendRoleNotificationEmail(ctx, projectUID, projectName, change.NewRoles, change.User.Email, recipientName, inviterName, projectURL)
@@ -158,6 +163,11 @@ func (s *ProjectsService) handleLFIDChange(ctx context.Context, projectUID, proj
 
 // handleNonLFIDChange sends invites for any newly-gained roles; removals are silently skipped.
 func (s *ProjectsService) handleNonLFIDChange(ctx context.Context, projectUID, projectName string, change userChange, recipientName, inviterName, projectURL string) error {
+	if !s.Config.InvitesEnabled {
+		slog.DebugContext(ctx, "project_subscriber: skipping invite — INVITES_ENABLED is false",
+			"project_uid", projectUID, "change_kind", change.Kind)
+		return nil
+	}
 	if change.Kind == changeRemoved {
 		slog.DebugContext(ctx, "project_subscriber: skipping removal notification for non-LFID user",
 			"project_uid", projectUID)

--- a/internal/service/project_subscriber_test.go
+++ b/internal/service/project_subscriber_test.go
@@ -643,6 +643,8 @@ func TestHandleProjectSettingsUpdated(t *testing.T) {
 				MessageBuilder:    mockMsg,
 				Config: ServiceConfig{
 					LFXSelfServeBaseURL: "https://app.dev.lfx.dev",
+					EmailsEnabled:       true,
+					InvitesEnabled:      true,
 				},
 			}
 
@@ -662,6 +664,68 @@ func TestHandleProjectSettingsUpdated(t *testing.T) {
 		msg := domain.NewMockMessage([]byte("not json"), "")
 		err := svc.HandleProjectSettingsUpdated(context.Background(), msg)
 		assert.NoError(t, err)
+	})
+
+	// Feature-flag disabled tests: verify no sends occur when the flags are off.
+
+	t.Run("EmailsEnabled=false — no email sent for LFID user added", func(t *testing.T) {
+		mockMsg := &domain.MockMessageBuilder{}
+		mockRepo := &domain.MockProjectRepository{}
+
+		event := events.ProjectSettingsUpdatedMessage{
+			ProjectUID:  "proj-flag",
+			OldSettings: events.ProjectSettings{},
+			NewSettings: events.ProjectSettings{
+				Writers: []events.UserInfo{alice},
+			},
+		}
+		mockRepo.On("GetProjectBase", mock.Anything, "proj-flag").
+			Return(makeProjectBase("proj-flag", "Flag Project", "flag-project"), nil)
+
+		svc := &ProjectsService{
+			ProjectRepository: mockRepo,
+			MessageBuilder:    mockMsg,
+			Config: ServiceConfig{
+				LFXSelfServeBaseURL: "https://app.dev.lfx.dev",
+				EmailsEnabled:       false,
+				InvitesEnabled:      true,
+			},
+		}
+
+		msg := domain.NewMockMessage(marshalEvent(t, event), "")
+		err := svc.HandleProjectSettingsUpdated(context.Background(), msg)
+		assert.NoError(t, err)
+		mockMsg.AssertNumberOfCalls(t, "SendEmailRequest", 0)
+	})
+
+	t.Run("InvitesEnabled=false — no invite sent for non-LFID user added", func(t *testing.T) {
+		mockMsg := &domain.MockMessageBuilder{}
+		mockRepo := &domain.MockProjectRepository{}
+
+		event := events.ProjectSettingsUpdatedMessage{
+			ProjectUID:  "proj-flag",
+			OldSettings: events.ProjectSettings{},
+			NewSettings: events.ProjectSettings{
+				Writers: []events.UserInfo{noLFIDWriter},
+			},
+		}
+		mockRepo.On("GetProjectBase", mock.Anything, "proj-flag").
+			Return(makeProjectBase("proj-flag", "Flag Project", "flag-project"), nil)
+
+		svc := &ProjectsService{
+			ProjectRepository: mockRepo,
+			MessageBuilder:    mockMsg,
+			Config: ServiceConfig{
+				LFXSelfServeBaseURL: "https://app.dev.lfx.dev",
+				EmailsEnabled:       true,
+				InvitesEnabled:      false,
+			},
+		}
+
+		msg := domain.NewMockMessage(marshalEvent(t, event), "")
+		err := svc.HandleProjectSettingsUpdated(context.Background(), msg)
+		assert.NoError(t, err)
+		mockMsg.AssertNumberOfCalls(t, "SendInviteRequest", 0)
 	})
 }
 

--- a/internal/service/project_subscriber_test.go
+++ b/internal/service/project_subscriber_test.go
@@ -696,6 +696,8 @@ func TestHandleProjectSettingsUpdated(t *testing.T) {
 		err := svc.HandleProjectSettingsUpdated(context.Background(), msg)
 		assert.NoError(t, err)
 		mockMsg.AssertNumberOfCalls(t, "SendEmailRequest", 0)
+		mockRepo.AssertExpectations(t)
+		mockMsg.AssertExpectations(t)
 	})
 
 	t.Run("InvitesEnabled=false — no invite sent for non-LFID user added", func(t *testing.T) {
@@ -726,6 +728,8 @@ func TestHandleProjectSettingsUpdated(t *testing.T) {
 		err := svc.HandleProjectSettingsUpdated(context.Background(), msg)
 		assert.NoError(t, err)
 		mockMsg.AssertNumberOfCalls(t, "SendInviteRequest", 0)
+		mockRepo.AssertExpectations(t)
+		mockMsg.AssertExpectations(t)
 	})
 }
 


### PR DESCRIPTION
## Summary

- Adds two independent env-var-driven boolean flags (`EMAILS_ENABLED`, `INVITES_ENABLED`) to gate outbound role-notification emails and invite requests
- Both default to `false` — each environment must explicitly opt in, preventing accidental sends in non-production environments
- Gates are placed at the mid-level handlers in `project_subscriber.go` (`handleLFIDChange` for emails, `handleNonLFIDChange` for invites), consistent with existing skip-log patterns in that file
- Helm chart and docs updated to match

## Changes

| File | What changed |
|------|-------------|
| `internal/service/project_service.go` | Added `EmailsEnabled` and `InvitesEnabled` fields to `ServiceConfig` |
| `internal/service/project_subscriber.go` | Early-return guards in `handleLFIDChange` and `handleNonLFIDChange` when respective flag is `false` |
| `cmd/project-api/main.go` | Parse `EMAILS_ENABLED`/`INVITES_ENABLED` from env in `parseEnv()`, wire into `ServiceConfig` in `main()` |
| `internal/service/project_subscriber_test.go` | Enable both flags in existing test setup; add two new sub-tests verifying sends are skipped when each flag is `false` |
| `charts/.../values.yaml` | `emailsEnabled: false`, `invitesEnabled: false` under `app:` |
| `charts/.../templates/deployment.yaml` | `EMAILS_ENABLED` and `INVITES_ENABLED` env entries |
| `CLAUDE.md` | Env var table updated |

## Usage

To enable in an environment set in Helm values:
```yaml
app:
  emailsEnabled: true   # enables role-notification emails to LFID users
  invitesEnabled: true  # enables invite requests for non-LFID users
```

Or via env vars directly: `EMAILS_ENABLED=true`, `INVITES_ENABLED=true`.


🤖 Generated with [Claude Code](https://claude.ai/code)