### PR TITLE
feat: add EMAIL_ALLOWED_DOMAINS to restrict outbound emails/invites by recipient domain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,7 @@ func TestEndpoint(t *testing.T) {
 | `LFX_SELF_SERVE_BASE_URL` | Base URL for project links in notification emails | derived from `LFX_ENVIRONMENT` | No |
 | `EMAILS_ENABLED` | Gate for outbound role-notification emails to LFID users (`true` to enable) | false | No |
 | `INVITES_ENABLED` | Gate for outbound invite requests to non-LFID users (`true` to enable) | false | No |
+| `EMAIL_ALLOWED_DOMAINS` | Comma-separated allowlist of recipient email domains (e.g. `linuxfoundation.org`). When empty all domains are permitted. Set in non-prod to prevent emails reaching real users. | "" (all domains) | No |
 
 ## Authorization (OpenFGA)
 

--- a/charts/lfx-v2-project-service/templates/deployment.yaml
+++ b/charts/lfx-v2-project-service/templates/deployment.yaml
@@ -49,6 +49,8 @@ spec:
               value: {{ .Values.app.emailsEnabled | quote }}
             - name: INVITES_ENABLED
               value: {{ .Values.app.invitesEnabled | quote }}
+            - name: EMAIL_ALLOWED_DOMAINS
+              value: {{ .Values.app.emailAllowedDomains | quote }}
             - name: JWT_AUTH_DISABLED_MOCK_LOCAL_PRINCIPAL
               value: {{ .Values.app.jwtAuthDisabledMockLocalPrincipal }}
             {{- with .Values.app.extraEnv }}

--- a/charts/lfx-v2-project-service/values.yaml
+++ b/charts/lfx-v2-project-service/values.yaml
@@ -69,6 +69,10 @@ app:
   # invitesEnabled gates outbound invite requests for non-LFID users via the invite service.
   # Disabled by default; set to true in environments where invite sending should be active.
   invitesEnabled: false
+  # emailAllowedDomains restricts outbound emails and invites to the listed recipient domains
+  # (comma-separated, e.g. "linuxfoundation.org"). When empty (the default) all domains are
+  # permitted. Set in non-prod environments to prevent accidental email to real users.
+  emailAllowedDomains: ""
   # jwtAuthDisabledMockLocalPrincipal mocks auth for local development to use a set principal
   # (only use for local development)
   jwtAuthDisabledMockLocalPrincipal: ""

--- a/cmd/project-api/main.go
+++ b/cmd/project-api/main.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -100,6 +101,7 @@ func main() {
 		LFXSelfServeBaseURL: env.LFXSelfServeBaseURL,
 		EmailsEnabled:       env.EmailsEnabled,
 		InvitesEnabled:      env.InvitesEnabled,
+		EmailAllowedDomains: env.EmailAllowedDomains,
 	})
 	svc := NewProjectsAPI(service)
 
@@ -167,6 +169,7 @@ type environment struct {
 	LFXSelfServeBaseURL string
 	EmailsEnabled       bool
 	InvitesEnabled      bool
+	EmailAllowedDomains []string
 }
 
 func parseEnv() environment {
@@ -194,6 +197,19 @@ func parseEnv() environment {
 			lfxSelfServeBaseURL = "https://app.dev.lfx.dev"
 		}
 	}
+	// EMAIL_ALLOWED_DOMAINS is a comma-separated list of recipient email domains that are
+	// permitted to receive outbound emails and invites. When empty, all domains are allowed.
+	var emailAllowedDomains []string
+	if raw := os.Getenv("EMAIL_ALLOWED_DOMAINS"); raw != "" {
+		for _, part := range strings.Split(raw, ",") {
+			domain := strings.ToLower(strings.TrimSpace(part))
+			domain = strings.TrimPrefix(domain, "@")
+			if domain != "" {
+				emailAllowedDomains = append(emailAllowedDomains, domain)
+			}
+		}
+	}
+
 	return environment{
 		NatsURL:             natsURL,
 		Port:                port,
@@ -201,6 +217,7 @@ func parseEnv() environment {
 		LFXSelfServeBaseURL: lfxSelfServeBaseURL,
 		EmailsEnabled:       os.Getenv("EMAILS_ENABLED") == "true",
 		InvitesEnabled:      os.Getenv("INVITES_ENABLED") == "true",
+		EmailAllowedDomains: emailAllowedDomains,
 	}
 }
 

--- a/internal/service/document_subscriber.go
+++ b/internal/service/document_subscriber.go
@@ -125,6 +125,12 @@ func (s *ProjectsService) handleProjectContentCreated(ctx context.Context, item 
 
 	for _, r := range recipients {
 		g.Go(func() error {
+			if !s.isRecipientDomainAllowed(r.Email) {
+				slog.DebugContext(gctx, "document_subscriber: skipping email — recipient domain not in EMAIL_ALLOWED_DOMAINS",
+					"project_uid", item.projectUID)
+				return nil
+			}
+
 			recipientName := r.Name
 			if recipientName == "" {
 				recipientName = r.Username

--- a/internal/service/document_subscriber_test.go
+++ b/internal/service/document_subscriber_test.go
@@ -34,6 +34,7 @@ func TestHandleProjectDocumentCreated(t *testing.T) {
 		wantEmailCount int
 		emailsEnabled  bool
 		folderName     string
+		allowedDomains []string
 	}{
 		{
 			name:           "notifies writer and auditor",
@@ -85,6 +86,22 @@ func TestHandleProjectDocumentCreated(t *testing.T) {
 			wantEmailCount: 0,
 			emailsEnabled:  false,
 		},
+		{
+			name:           "EmailAllowedDomains set — disallowed domain skipped",
+			event:          events.ProjectDocumentCreatedMessage{ProjectUID: "proj-1", Name: "Doc", FileName: "doc.pdf", CreatedBy: "uploader"},
+			settings:       baseSettings([]models.UserInfo{writer}, []models.UserInfo{auditor}),
+			wantEmailCount: 0,
+			emailsEnabled:  true,
+			allowedDomains: []string{"linuxfoundation.org"},
+		},
+		{
+			name:           "EmailAllowedDomains set — allowed domain sends",
+			event:          events.ProjectDocumentCreatedMessage{ProjectUID: "proj-1", Name: "Doc", FileName: "doc.pdf", CreatedBy: "uploader"},
+			settings:       baseSettings([]models.UserInfo{writer}, []models.UserInfo{auditor}),
+			wantEmailCount: 2,
+			emailsEnabled:  true,
+			allowedDomains: []string{"example.com"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -126,6 +143,7 @@ func TestHandleProjectDocumentCreated(t *testing.T) {
 				Config: ServiceConfig{
 					LFXSelfServeBaseURL: "https://app.dev.lfx.dev",
 					EmailsEnabled:       tt.emailsEnabled,
+					EmailAllowedDomains: tt.allowedDomains,
 				},
 			}
 
@@ -224,6 +242,7 @@ func TestHandleProjectLinkCreated(t *testing.T) {
 		settings       *models.ProjectSettings
 		wantEmailCount int
 		emailsEnabled  bool
+		allowedDomains []string
 	}{
 		{
 			name:           "notifies writer and auditor",
@@ -245,6 +264,22 @@ func TestHandleProjectLinkCreated(t *testing.T) {
 			settings:       baseSettings([]models.UserInfo{writer}, []models.UserInfo{auditor}),
 			wantEmailCount: 0,
 			emailsEnabled:  false,
+		},
+		{
+			name:           "EmailAllowedDomains set — disallowed domain skipped",
+			event:          events.ProjectLinkCreatedMessage{ProjectUID: "proj-1", Name: "Spec Link", URL: "https://specs.example.com", CreatedBy: "uploader"},
+			settings:       baseSettings([]models.UserInfo{writer}, []models.UserInfo{auditor}),
+			wantEmailCount: 0,
+			emailsEnabled:  true,
+			allowedDomains: []string{"linuxfoundation.org"},
+		},
+		{
+			name:           "EmailAllowedDomains set — allowed domain sends",
+			event:          events.ProjectLinkCreatedMessage{ProjectUID: "proj-1", Name: "Spec Link", URL: "https://specs.example.com", CreatedBy: "uploader"},
+			settings:       baseSettings([]models.UserInfo{writer}, []models.UserInfo{auditor}),
+			wantEmailCount: 2,
+			emailsEnabled:  true,
+			allowedDomains: []string{"example.com"},
 		},
 	}
 
@@ -276,6 +311,7 @@ func TestHandleProjectLinkCreated(t *testing.T) {
 				Config: ServiceConfig{
 					LFXSelfServeBaseURL: "https://app.dev.lfx.dev",
 					EmailsEnabled:       tt.emailsEnabled,
+					EmailAllowedDomains: tt.allowedDomains,
 				},
 			}
 

--- a/internal/service/project_service.go
+++ b/internal/service/project_service.go
@@ -46,4 +46,9 @@ type ServiceConfig struct {
 	// InvitesEnabled gates outbound invite requests for non-LFID users via the invite service.
 	// Disabled by default; set INVITES_ENABLED=true to enable.
 	InvitesEnabled bool
+	// EmailAllowedDomains is an allowlist of recipient email domains for outbound emails and invites.
+	// When empty (the default) all domains are permitted. When set, only recipients whose email
+	// domain (case-insensitive, exact match) appears in the list will receive messages.
+	// Set via EMAIL_ALLOWED_DOMAINS (comma-separated, e.g. "linuxfoundation.org").
+	EmailAllowedDomains []string
 }

--- a/internal/service/project_subscriber.go
+++ b/internal/service/project_subscriber.go
@@ -135,6 +135,11 @@ func (s *ProjectsService) handleLFIDChange(ctx context.Context, projectUID, proj
 			"project_uid", projectUID, "change_kind", change.Kind)
 		return nil
 	}
+	if !s.isRecipientDomainAllowed(change.User.Email) {
+		slog.DebugContext(ctx, "project_subscriber: skipping email — recipient domain not in EMAIL_ALLOWED_DOMAINS",
+			"project_uid", projectUID, "change_kind", change.Kind)
+		return nil
+	}
 	switch change.Kind {
 	case changeAdded:
 		return s.sendRoleNotificationEmail(ctx, projectUID, projectName, change.NewRoles, change.User.Email, recipientName, inviterName, projectURL)
@@ -165,6 +170,11 @@ func (s *ProjectsService) handleLFIDChange(ctx context.Context, projectUID, proj
 func (s *ProjectsService) handleNonLFIDChange(ctx context.Context, projectUID, projectName string, change userChange, recipientName, inviterName, projectURL string) error {
 	if !s.Config.InvitesEnabled {
 		slog.DebugContext(ctx, "project_subscriber: skipping invite — INVITES_ENABLED is false",
+			"project_uid", projectUID, "change_kind", change.Kind)
+		return nil
+	}
+	if !s.isRecipientDomainAllowed(change.User.Email) {
+		slog.DebugContext(ctx, "project_subscriber: skipping invite — recipient domain not in EMAIL_ALLOWED_DOMAINS",
 			"project_uid", projectUID, "change_kind", change.Kind)
 		return nil
 	}
@@ -893,4 +903,26 @@ func rolesForDisplay(roles []string) []string {
 		return []string{"Manage"}
 	}
 	return result
+}
+
+// isRecipientDomainAllowed reports whether an outbound email or invite may be sent to addr.
+// When no allowlist is configured (Config.EmailAllowedDomains is empty) all addresses are
+// permitted. Otherwise the domain portion of addr (the part after the last "@") must match
+// one of the allowed domains (case-insensitive, exact match). Addresses without an "@" are
+// considered malformed and are not allowed.
+func (s *ProjectsService) isRecipientDomainAllowed(addr string) bool {
+	if len(s.Config.EmailAllowedDomains) == 0 {
+		return true
+	}
+	at := strings.LastIndex(addr, "@")
+	if at < 0 {
+		return false
+	}
+	domain := strings.ToLower(addr[at+1:])
+	for _, allowed := range s.Config.EmailAllowedDomains {
+		if domain == allowed {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/service/project_subscriber.go
+++ b/internal/service/project_subscriber.go
@@ -920,7 +920,7 @@ func (s *ProjectsService) isRecipientDomainAllowed(addr string) bool {
 	}
 	domain := strings.ToLower(addr[at+1:])
 	for _, allowed := range s.Config.EmailAllowedDomains {
-		if domain == allowed {
+		if domain == strings.ToLower(allowed) {
 			return true
 		}
 	}

--- a/internal/service/project_subscriber_test.go
+++ b/internal/service/project_subscriber_test.go
@@ -1413,6 +1413,12 @@ func TestProjectsService_isRecipientDomainAllowed(t *testing.T) {
 			addr:    "user@sub.linuxfoundation.org",
 			want:    false,
 		},
+		{
+			name:    "mixed-case allowlist entry — allowed",
+			domains: []string{"LinuxFoundation.ORG"},
+			addr:    "user@linuxfoundation.org",
+			want:    true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/service/project_subscriber_test.go
+++ b/internal/service/project_subscriber_test.go
@@ -731,6 +731,74 @@ func TestHandleProjectSettingsUpdated(t *testing.T) {
 		mockRepo.AssertExpectations(t)
 		mockMsg.AssertExpectations(t)
 	})
+
+	t.Run("EmailAllowedDomains set — LFID user with disallowed domain skipped", func(t *testing.T) {
+		mockMsg := &domain.MockMessageBuilder{}
+		mockRepo := &domain.MockProjectRepository{}
+
+		// alice has @example.com — not in the allowlist.
+		event := events.ProjectSettingsUpdatedMessage{
+			ProjectUID:  "proj-flag",
+			OldSettings: events.ProjectSettings{},
+			NewSettings: events.ProjectSettings{
+				Writers: []events.UserInfo{alice},
+			},
+		}
+		mockRepo.On("GetProjectBase", mock.Anything, "proj-flag").
+			Return(makeProjectBase("proj-flag", "Flag Project", "flag-project"), nil)
+
+		svc := &ProjectsService{
+			ProjectRepository: mockRepo,
+			MessageBuilder:    mockMsg,
+			Config: ServiceConfig{
+				LFXSelfServeBaseURL: "https://app.dev.lfx.dev",
+				EmailsEnabled:       true,
+				InvitesEnabled:      true,
+				EmailAllowedDomains: []string{"linuxfoundation.org"},
+			},
+		}
+
+		msg := domain.NewMockMessage(marshalEvent(t, event), "")
+		err := svc.HandleProjectSettingsUpdated(context.Background(), msg)
+		assert.NoError(t, err)
+		mockMsg.AssertNumberOfCalls(t, "SendEmailRequest", 0)
+		mockRepo.AssertExpectations(t)
+		mockMsg.AssertExpectations(t)
+	})
+
+	t.Run("EmailAllowedDomains set — non-LFID user with disallowed domain invite skipped", func(t *testing.T) {
+		mockMsg := &domain.MockMessageBuilder{}
+		mockRepo := &domain.MockProjectRepository{}
+
+		// noLFIDWriter has @example.com — not in the allowlist.
+		event := events.ProjectSettingsUpdatedMessage{
+			ProjectUID:  "proj-flag",
+			OldSettings: events.ProjectSettings{},
+			NewSettings: events.ProjectSettings{
+				Writers: []events.UserInfo{noLFIDWriter},
+			},
+		}
+		mockRepo.On("GetProjectBase", mock.Anything, "proj-flag").
+			Return(makeProjectBase("proj-flag", "Flag Project", "flag-project"), nil)
+
+		svc := &ProjectsService{
+			ProjectRepository: mockRepo,
+			MessageBuilder:    mockMsg,
+			Config: ServiceConfig{
+				LFXSelfServeBaseURL: "https://app.dev.lfx.dev",
+				EmailsEnabled:       true,
+				InvitesEnabled:      true,
+				EmailAllowedDomains: []string{"linuxfoundation.org"},
+			},
+		}
+
+		msg := domain.NewMockMessage(marshalEvent(t, event), "")
+		err := svc.HandleProjectSettingsUpdated(context.Background(), msg)
+		assert.NoError(t, err)
+		mockMsg.AssertNumberOfCalls(t, "SendInviteRequest", 0)
+		mockRepo.AssertExpectations(t)
+		mockMsg.AssertExpectations(t)
+	})
 }
 
 func TestMapRoleToInviteRole(t *testing.T) {
@@ -1280,6 +1348,82 @@ func TestStoreInviteInfo(t *testing.T) {
 
 			mockRepo.AssertExpectations(t)
 			mockMsg.AssertExpectations(t)
+		})
+	}
+}
+
+func TestProjectsService_isRecipientDomainAllowed(t *testing.T) {
+	tests := []struct {
+		name    string
+		domains []string
+		addr    string
+		want    bool
+	}{
+		{
+			name:    "empty allowlist — all addresses allowed",
+			domains: nil,
+			addr:    "user@example.com",
+			want:    true,
+		},
+		{
+			name:    "matching domain — allowed",
+			domains: []string{"linuxfoundation.org"},
+			addr:    "user@linuxfoundation.org",
+			want:    true,
+		},
+		{
+			name:    "non-matching domain — blocked",
+			domains: []string{"linuxfoundation.org"},
+			addr:    "user@gmail.com",
+			want:    false,
+		},
+		{
+			name:    "case-insensitive domain comparison — allowed",
+			domains: []string{"linuxfoundation.org"},
+			addr:    "user@LINUXFOUNDATION.ORG",
+			want:    true,
+		},
+		{
+			name:    "multiple allowed domains — matches second entry",
+			domains: []string{"linuxfoundation.org", "example.org"},
+			addr:    "user@example.org",
+			want:    true,
+		},
+		{
+			name:    "multiple allowed domains — no match",
+			domains: []string{"linuxfoundation.org", "example.org"},
+			addr:    "user@gmail.com",
+			want:    false,
+		},
+		{
+			name:    "malformed address with no @ — blocked",
+			domains: []string{"linuxfoundation.org"},
+			addr:    "notanemail",
+			want:    false,
+		},
+		{
+			name:    "empty address — blocked",
+			domains: []string{"linuxfoundation.org"},
+			addr:    "",
+			want:    false,
+		},
+		{
+			name:    "subdomain not in allowlist — blocked (exact match only)",
+			domains: []string{"linuxfoundation.org"},
+			addr:    "user@sub.linuxfoundation.org",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &ProjectsService{
+				Config: ServiceConfig{
+					EmailAllowedDomains: tt.domains,
+				},
+			}
+			got := svc.isRecipientDomainAllowed(tt.addr)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `EMAIL_ALLOWED_DOMAINS` env var (comma-separated domain list) to gate outbound role-notification emails and invite requests by recipient domain
- When unset or empty (the default), all domains are permitted — no change to prod behaviour
- When set, only recipients whose email domain exactly matches an entry in the list will receive messages; applies to both LFID emails (`handleLFIDChange`) and non-LFID invites (`handleNonLFIDChange`)
- Helm chart exposes `app.emailAllowedDomains` → `EMAIL_ALLOWED_DOMAINS` in the pod env
- ArgoCD overlays for dev and staging set `linuxfoundation.org` in a companion PR (lfx-v2-argocd)

## Test plan

- [x] `make test` passes — all existing + new tests green
- [x] `make build` succeeds
- [x] `golangci-lint` — 0 issues
- [x] New unit tests cover: empty allowlist (permit all), matching domain, non-matching domain, case-insensitivity, malformed address, subdomain exact-match (`TestProjectsService_isRecipientDomainAllowed`)
- [x] Two new sub-tests in `TestHandleProjectSettingsUpdated` assert LFID email and non-LFID invite are skipped when domain is not in allowlist
- [x] Helm template renders `EMAIL_ALLOWED_DOMAINS` from `app.emailAllowedDomains` (`helm template` confirms the env entry)

## Notes

- `document_subscriber.go` (document/link upload notifications) is part of a separate in-progress feature branch and is not in main; the domain filter will be applied there when that feature lands
- Subdomain matching is **not** supported — `sub.linuxfoundation.org` does not match `linuxfoundation.org` (intentional, exact match only)

🤖 Generated with [Claude Code](https://claude.ai/code)