### PR TITLE
Fix Datadog trace resource names

### DIFF
--- a/cmd/project-api/main.go
+++ b/cmd/project-api/main.go
@@ -19,7 +19,10 @@ import (
 
 	nats "github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
+	"github.com/go-chi/chi/v5"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"
 
 	inviteapi "github.com/linuxfoundation/lfx-v2-invite-service/pkg/api"
@@ -245,6 +248,29 @@ func setupHTTPServer(flags flags, svc *ProjectsAPI, gracefulCloseWG *sync.WaitGr
 		koDataDir,
 		koDataDir,
 	)
+
+	// Register route-tagging middleware inside chi's routing chain so that
+	// http.route is set on the OTel span after chi has matched the route pattern.
+	// The span name is also updated here to avoid high-cardinality names from
+	// using raw URL paths (which contain actual path parameter values).
+	// Must be registered before Mount calls per chi convention.
+	// Reads RoutePattern after next.ServeHTTP because chi populates the pattern
+	// during routing (inside ServeHTTP), not before.
+	mux.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r)
+			rctx := chi.RouteContext(r.Context())
+			if rctx != nil {
+				routePattern := rctx.RoutePattern()
+				if routePattern != "" {
+					if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
+						labeler.Add(semconv.HTTPRoute(routePattern))
+					}
+					trace.SpanFromContext(r.Context()).SetName(r.Method + " " + routePattern)
+				}
+			}
+		})
+	})
 
 	// Mount the handler on the mux
 	genhttp.Mount(mux, genHttpServer)

--- a/cmd/project-api/main.go
+++ b/cmd/project-api/main.go
@@ -17,9 +17,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/go-chi/chi/v5"
 	nats "github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
-	"github.com/go-chi/chi/v5"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 	"go.opentelemetry.io/otel/trace"
@@ -258,17 +258,19 @@ func setupHTTPServer(flags flags, svc *ProjectsAPI, gracefulCloseWG *sync.WaitGr
 	// during routing (inside ServeHTTP), not before.
 	mux.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			next.ServeHTTP(w, r)
-			rctx := chi.RouteContext(r.Context())
-			if rctx != nil {
-				routePattern := rctx.RoutePattern()
-				if routePattern != "" {
-					if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
-						labeler.Add(semconv.HTTPRoute(routePattern))
+			defer func() {
+				rctx := chi.RouteContext(r.Context())
+				if rctx != nil {
+					routePattern := rctx.RoutePattern()
+					if routePattern != "" {
+						if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
+							labeler.Add(semconv.HTTPRoute(routePattern))
+						}
+						trace.SpanFromContext(r.Context()).SetName(r.Method + " " + routePattern)
 					}
-					trace.SpanFromContext(r.Context()).SetName(r.Method + " " + routePattern)
 				}
-			}
+			}()
+			next.ServeHTTP(w, r)
 		})
 	})
 

--- a/cmd/project-api/main.go
+++ b/cmd/project-api/main.go
@@ -266,7 +266,9 @@ func setupHTTPServer(flags flags, svc *ProjectsAPI, gracefulCloseWG *sync.WaitGr
 						if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
 							labeler.Add(semconv.HTTPRoute(routePattern))
 						}
-						trace.SpanFromContext(r.Context()).SetName(r.Method + " " + routePattern)
+						span := trace.SpanFromContext(r.Context())
+						span.SetAttributes(semconv.HTTPRoute(routePattern))
+						span.SetName(r.Method + " " + routePattern)
 					}
 				}
 			}()

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.0
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.20.10
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.92.0
+	github.com/go-chi/chi/v5 v5.2.3
 	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/google/uuid v1.6.0
 	github.com/linuxfoundation/lfx-v2-email-service v0.1.0
@@ -32,6 +33,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/log v0.19.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
 	goa.design/goa/v3 v3.22.6
 	golang.org/x/sync v0.20.0
 )
@@ -59,7 +61,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dimfeld/httppath v0.0.0-20170720192232-ee938bf73598 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/go-chi/chi/v5 v5.2.3 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gohugoio/hashstructure v0.6.0 // indirect
@@ -76,7 +77,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/mod v0.33.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,10 +85,6 @@ github.com/linuxfoundation/lfx-v2-fga-sync v0.2.17 h1:ZW2PyrEPB6SmT14qa3qlrcU4rB
 github.com/linuxfoundation/lfx-v2-fga-sync v0.2.17/go.mod h1:075J7/39UbsuLsJCXgVkbpKK1VIuPa7gbyhLsoTBAXo=
 github.com/linuxfoundation/lfx-v2-indexer-service v0.4.14-0.20260109191409-7371e293d8b5 h1:Ic06r/3OO4wP2Y2eL9InXEKRSVq2cqbNGBTsdr493YA=
 github.com/linuxfoundation/lfx-v2-indexer-service v0.4.14-0.20260109191409-7371e293d8b5/go.mod h1:j013GdKST/hMWFhciRuzJd0sy764sNtlmO3gqmsnaCA=
-github.com/linuxfoundation/lfx-v2-invite-service v0.0.0-20260519211352-0451da07c865 h1:0PW+4gTUTmLU6EUQwZxyZT8D+ZWhbsYG+xRDw+0kSEg=
-github.com/linuxfoundation/lfx-v2-invite-service v0.0.0-20260519211352-0451da07c865/go.mod h1:YJ/st6t/Vjt3+t7jel6/hVLPwvcKdgAkVbbJVw3PGtE=
-github.com/linuxfoundation/lfx-v2-invite-service v0.0.0-20260519214332-6ddba73f7fc5 h1:3AQX/Ge7gJZV4/CM/KrhSuO0SdbVG6m1ntG0sGp32P0=
-github.com/linuxfoundation/lfx-v2-invite-service v0.0.0-20260519214332-6ddba73f7fc5/go.mod h1:YJ/st6t/Vjt3+t7jel6/hVLPwvcKdgAkVbbJVw3PGtE=
 github.com/linuxfoundation/lfx-v2-invite-service v0.0.0-20260520171722-e76421ce1305 h1:jHNYpxuJ5re8Wjidk59AvlH83ILnyDQrQF5jfV17zSg=
 github.com/linuxfoundation/lfx-v2-invite-service v0.0.0-20260520171722-e76421ce1305/go.mod h1:YJ/st6t/Vjt3+t7jel6/hVLPwvcKdgAkVbbJVw3PGtE=
 github.com/manveru/faker v0.0.0-20171103152722-9fbc68a78c4d h1:Zj+PHjnhRYWBK6RqCDBcAhLXoi3TzC27Zad/Vn+gnVQ=


### PR DESCRIPTION
## Summary

- Add chi route-tagging middleware to set `http.route` on OTel spans after chi matches the route pattern
- Update `trace.SpanFromContext().SetName()` with the matched route pattern so Datadog shows `GET /api/v1/projects/{id}` instead of just `GET`
- Promote `chi/v5` and `otel/trace` from indirect to direct dependencies in `go.mod`

Fixes low-cardinality Datadog trace resource names across the service by reading the chi route pattern post-`ServeHTTP` (the only point at which chi has populated it).

JIRA: [LFXV2-1935](https://linuxfoundation.atlassian.net/browse/LFXV2-1935)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1935]: https://linuxfoundation.atlassian.net/browse/LFXV2-1935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ