### PR TITLE
[LFXV2-2079] feat: invite structured fields and email-based reconciliation

### DIFF
--- a/cmd/project-api/main.go
+++ b/cmd/project-api/main.go
@@ -483,7 +483,7 @@ func createNatsSubcriptions(ctx context.Context, svc *ProjectsAPI, natsConn *nat
 	}
 	for _, eh := range []eventHandler{
 		{constants.ProjectSettingsUpdatedSubject, svc.service.HandleProjectSettingsUpdated},
-		{inviteapi.InviteAcceptedSubject, svc.service.HandleInviteAccepted},
+		{inviteapi.InviteServiceAcceptedSubject, svc.service.HandleInviteAccepted},
 		{constants.ProjectDocumentCreatedSubject, svc.service.HandleProjectDocumentCreated},
 		{constants.ProjectLinkCreatedSubject, svc.service.HandleProjectLinkCreated},
 	} {

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/linuxfoundation/lfx-v2-email-service v0.1.0
 	github.com/linuxfoundation/lfx-v2-fga-sync v0.2.17
 	github.com/linuxfoundation/lfx-v2-indexer-service v0.4.14-0.20260109191409-7371e293d8b5
-	github.com/linuxfoundation/lfx-v2-invite-service v0.0.0-20260520171722-e76421ce1305
+	github.com/linuxfoundation/lfx-v2-invite-service v0.1.4-0.20260603200146-27b0e0162e1d
 	github.com/nats-io/nats.go v1.47.0
 	github.com/remychantenay/slog-otel v1.3.4
 	github.com/rustyoz/svg v0.0.0-20250705135709-8b1786137cb3

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/linuxfoundation/lfx-v2-indexer-service v0.4.14-0.20260109191409-7371e
 github.com/linuxfoundation/lfx-v2-indexer-service v0.4.14-0.20260109191409-7371e293d8b5/go.mod h1:j013GdKST/hMWFhciRuzJd0sy764sNtlmO3gqmsnaCA=
 github.com/linuxfoundation/lfx-v2-invite-service v0.0.0-20260520171722-e76421ce1305 h1:jHNYpxuJ5re8Wjidk59AvlH83ILnyDQrQF5jfV17zSg=
 github.com/linuxfoundation/lfx-v2-invite-service v0.0.0-20260520171722-e76421ce1305/go.mod h1:YJ/st6t/Vjt3+t7jel6/hVLPwvcKdgAkVbbJVw3PGtE=
+github.com/linuxfoundation/lfx-v2-invite-service v0.1.4-0.20260603200146-27b0e0162e1d h1:G+KYq8Jy9CnZilJk89q0nvTEHYfYjNpQ1GpwghdiNvc=
+github.com/linuxfoundation/lfx-v2-invite-service v0.1.4-0.20260603200146-27b0e0162e1d/go.mod h1:YJ/st6t/Vjt3+t7jel6/hVLPwvcKdgAkVbbJVw3PGtE=
 github.com/manveru/faker v0.0.0-20171103152722-9fbc68a78c4d h1:Zj+PHjnhRYWBK6RqCDBcAhLXoi3TzC27Zad/Vn+gnVQ=
 github.com/manveru/faker v0.0.0-20171103152722-9fbc68a78c4d/go.mod h1:WZy8Q5coAB1zhY9AOBJP0O6J4BuDfbupUDavKY+I3+s=
 github.com/manveru/gobdd v0.0.0-20131210092515-f1a17fdd710b h1:3E44bLeN8uKYdfQqVQycPnaVviZdBLbizFhU49mtbe4=

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -45,10 +45,6 @@ var (
 	// ErrFolderNotEmpty is returned when attempting to delete a folder that still contains links or documents.
 	ErrFolderNotEmpty = errors.New("folder cannot be deleted because it contains links or documents; remove all items from the folder first")
 
-	// ErrInviteMappingNotFound is returned when no invite→project mapping exists for the given invite UID.
-	// This is distinct from ErrProjectNotFound: the project may exist but no mapping was written for this invite.
-	ErrInviteMappingNotFound = errors.New("invite mapping not found")
-
 	// ErrUserNotFound is returned by UserReader when no registered user matches the given lookup criteria.
 	// It is handled internally (treated as a lookup miss) and is never surfaced to the HTTP layer.
 	ErrUserNotFound = errors.New("user not found")

--- a/internal/domain/errors_test.go
+++ b/internal/domain/errors_test.go
@@ -186,7 +186,6 @@ func TestErrorTypes(t *testing.T) {
 		ErrUnmarshal,
 		ErrServiceUnavailable,
 		ErrValidationFailed,
-		ErrInviteMappingNotFound,
 	}
 
 	for i, err := range domainErrors {

--- a/internal/domain/mock.go
+++ b/internal/domain/mock.go
@@ -104,21 +104,6 @@ func (m *MockProjectRepository) CreateProject(ctx context.Context, projectBase *
 	return args.Error(0)
 }
 
-func (m *MockProjectRepository) CreateInviteMapping(ctx context.Context, inviteUID, projectUID string) error {
-	args := m.Called(ctx, inviteUID, projectUID)
-	return args.Error(0)
-}
-
-func (m *MockProjectRepository) GetProjectUIDByInviteUID(ctx context.Context, inviteUID string) (string, error) {
-	args := m.Called(ctx, inviteUID)
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockProjectRepository) DeleteInviteMapping(ctx context.Context, inviteUID string) error {
-	args := m.Called(ctx, inviteUID)
-	return args.Error(0)
-}
-
 func (m *MockProjectRepository) DeleteProject(ctx context.Context, projectUID string, revision uint64) error {
 	args := m.Called(ctx, projectUID, revision)
 	return args.Error(0)

--- a/internal/domain/repository.go
+++ b/internal/domain/repository.go
@@ -27,12 +27,6 @@ type ProjectRepository interface {
 	GetProjectSettingsWithRevision(ctx context.Context, projectUID string) (*models.ProjectSettings, uint64, error)
 	UpdateProjectSettings(ctx context.Context, projectSettings *models.ProjectSettings, revision uint64) error
 
-	// Invite mappings — secondary mappings from invite UID → project UID for fast
-	// invite-acceptance routing without scanning all project settings.
-	CreateInviteMapping(ctx context.Context, inviteUID, projectUID string) error
-	GetProjectUIDByInviteUID(ctx context.Context, inviteUID string) (string, error)
-	DeleteInviteMapping(ctx context.Context, inviteUID string) error
-
 	// Slug operations
 	GetProjectUIDFromSlug(ctx context.Context, projectSlug string) (string, error)
 	ProjectSlugExists(ctx context.Context, projectSlug string) (bool, error)

--- a/internal/infrastructure/nats/message.go
+++ b/internal/infrastructure/nats/message.go
@@ -230,13 +230,13 @@ func (m *MessageBuilder) SendInviteRequest(ctx context.Context, req inviteapi.Se
 		}
 	}
 
-	if resp.Invite == nil || resp.Invite.UID == "" {
+	if resp.InviteData == nil || resp.UID == "" {
 		return domain.InviteResult{}, fmt.Errorf("invite service returned success but invite_uid is empty")
 	}
 	result := domain.InviteResult{
-		InviteUID:      resp.Invite.UID,
-		RecipientEmail: resp.Invite.Email,
-		ExpiresAt:      resp.Invite.ExpiresAt,
+		InviteUID:      resp.UID,
+		RecipientEmail: resp.Email,
+		ExpiresAt:      resp.ExpiresAt,
 	}
 	slog.DebugContext(ctx, "invite service replied", "invite_uid", result.InviteUID, "expires_at", result.ExpiresAt)
 	return result, nil

--- a/internal/infrastructure/nats/message_test.go
+++ b/internal/infrastructure/nats/message_test.go
@@ -632,9 +632,9 @@ func TestMessageBuilder_SendInviteRequest(t *testing.T) {
 		{
 			name: "invite service returns error in response body — error returned",
 			req: inviteapi.SendInviteRequest{
-				RecipientEmail: "user@example.com",
-				ResourceUID:    "proj-123",
-				Role:           string(inviteapi.InviteRoleView),
+				Recipient: &inviteapi.Recipient{Email: "user@example.com"},
+				Resource:  &inviteapi.Resource{UID: "proj-123"},
+				Role:      string(inviteapi.InviteRoleView),
 			},
 			setupMocks: func(mockConn *MockNATSConn) {
 				replyData, _ := json.Marshal(inviteapi.SendInviteResponse{Error: "recipient not found"})
@@ -646,9 +646,9 @@ func TestMessageBuilder_SendInviteRequest(t *testing.T) {
 		{
 			name: "NATS request error — error returned",
 			req: inviteapi.SendInviteRequest{
-				RecipientEmail: "user@example.com",
-				ResourceUID:    "proj-123",
-				Role:           string(inviteapi.InviteRoleView),
+				Recipient: &inviteapi.Recipient{Email: "user@example.com"},
+				Resource:  &inviteapi.Resource{UID: "proj-123"},
+				Role:      string(inviteapi.InviteRoleView),
 			},
 			setupMocks: func(mockConn *MockNATSConn) {
 				mockConn.On("RequestMsgWithContext", mock.Anything, mock.AnythingOfType("*nats.Msg")).

--- a/internal/infrastructure/nats/message_test.go
+++ b/internal/infrastructure/nats/message_test.go
@@ -577,19 +577,25 @@ func TestMessageBuilder_SendInviteRequest(t *testing.T) {
 		{
 			name: "successful request — correct subject, payload, and invite result returned",
 			req: inviteapi.SendInviteRequest{
-				RecipientEmail: "user@example.com",
-				RecipientName:  "Jane Doe",
-				InviterName:    "Admin",
-				ResourceUID:    "proj-123",
-				ResourceName:   "Demo Project",
-				ResourceType:   "project",
-				Role:           string(inviteapi.InviteRoleManage),
-				ReturnURL:      "https://app.lfx.dev/project/overview?project=demo",
+				Recipient: &inviteapi.Recipient{
+					Email: "user@example.com",
+					Name:  "Jane Doe",
+				},
+				Inviter: &inviteapi.Inviter{
+					Name: "Admin",
+				},
+				Resource: &inviteapi.Resource{
+					UID:  "proj-123",
+					Name: "Demo Project",
+					Type: "project",
+				},
+				Role:      string(inviteapi.InviteRoleManage),
+				ReturnURL: "https://app.lfx.dev/project/overview?project=demo",
 			},
 			setupMocks: func(mockConn *MockNATSConn) {
 				expiresAt := now.Add(7 * 24 * time.Hour)
 				replyData, _ := json.Marshal(inviteapi.SendInviteResponse{
-					Invite: &inviteapi.InviteData{
+					InviteData: &inviteapi.InviteData{
 						UID:       "invite-abc-123",
 						Email:     "user@example.com",
 						ExpiresAt: expiresAt,
@@ -603,12 +609,15 @@ func TestMessageBuilder_SendInviteRequest(t *testing.T) {
 					if err := json.Unmarshal(msg.Data, &got); err != nil {
 						return false
 					}
-					return got.RecipientEmail == "user@example.com" &&
-						got.RecipientName == "Jane Doe" &&
-						got.InviterName == "Admin" &&
-						got.ResourceUID == "proj-123" &&
-						got.ResourceName == "Demo Project" &&
-						got.ResourceType == "project" &&
+					return got.Recipient != nil &&
+						got.Recipient.Email == "user@example.com" &&
+						got.Recipient.Name == "Jane Doe" &&
+						got.Inviter != nil &&
+						got.Inviter.Name == "Admin" &&
+						got.Resource != nil &&
+						got.Resource.UID == "proj-123" &&
+						got.Resource.Name == "Demo Project" &&
+						got.Resource.Type == "project" &&
 						got.Role == string(inviteapi.InviteRoleManage) &&
 						got.ReturnURL == "https://app.lfx.dev/project/overview?project=demo"
 				})).Return(&nats.Msg{Data: replyData}, nil)

--- a/internal/infrastructure/nats/repository.go
+++ b/internal/infrastructure/nats/repository.go
@@ -178,6 +178,9 @@ func (s *NatsRepository) ListAllProjectsSettings(ctx context.Context) ([]*models
 
 	projectsSettings := []*models.ProjectSettings{}
 	for key := range keysLister.Keys() {
+		if strings.HasPrefix(key, "lookup/") {
+			continue
+		}
 		entry, err := s.ProjectSettings.Get(ctx, key)
 		if err != nil {
 			slog.ErrorContext(ctx, "error getting project settings from NATS KV store", constants.ErrKey, err, "project_uid", key)

--- a/internal/infrastructure/nats/repository.go
+++ b/internal/infrastructure/nats/repository.go
@@ -414,42 +414,6 @@ func (s *NatsRepository) UpdateProjectSettings(ctx context.Context, projectSetti
 	return nil
 }
 
-// CreateInviteMapping writes the invite UID → project UID mapping into the project-settings KV bucket.
-func (s *NatsRepository) CreateInviteMapping(ctx context.Context, inviteUID, projectUID string) error {
-	key := fmt.Sprintf(constants.KVLookupInviteMappingPrefix, inviteUID)
-	_, err := s.ProjectSettings.Put(ctx, key, []byte(projectUID))
-	if err != nil {
-		slog.ErrorContext(ctx, "error writing invite mapping to NATS KV store", constants.ErrKey, err, "invite_uid", inviteUID, "project_uid", projectUID)
-		return domain.ErrInternal
-	}
-	return nil
-}
-
-// GetProjectUIDByInviteUID resolves an invite UID to its project UID via the mapping.
-func (s *NatsRepository) GetProjectUIDByInviteUID(ctx context.Context, inviteUID string) (string, error) {
-	key := fmt.Sprintf(constants.KVLookupInviteMappingPrefix, inviteUID)
-	entry, err := s.ProjectSettings.Get(ctx, key)
-	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			return "", domain.ErrInviteMappingNotFound
-		}
-		slog.ErrorContext(ctx, "error reading invite mapping from NATS KV store", constants.ErrKey, err, "invite_uid", inviteUID)
-		return "", domain.ErrInternal
-	}
-	return string(entry.Value()), nil
-}
-
-// DeleteInviteMapping removes the invite UID → project UID mapping once the invite is consumed.
-func (s *NatsRepository) DeleteInviteMapping(ctx context.Context, inviteUID string) error {
-	key := fmt.Sprintf(constants.KVLookupInviteMappingPrefix, inviteUID)
-	err := s.ProjectSettings.Delete(ctx, key)
-	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
-		slog.ErrorContext(ctx, "error deleting invite mapping from NATS KV store", constants.ErrKey, err, "invite_uid", inviteUID)
-		return domain.ErrInternal
-	}
-	return nil
-}
-
 func (s *NatsRepository) deleteProjectSlugMapping(ctx context.Context, projectSlug string) error {
 	err := s.Projects.Delete(ctx, fmt.Sprintf("slug/%s", projectSlug))
 	if err != nil {

--- a/internal/service/project_subscriber.go
+++ b/internal/service/project_subscriber.go
@@ -245,118 +245,9 @@ func (s *ProjectsService) sendInvite(ctx context.Context, projectUID, projectNam
 			constants.ErrKey, err, "role", role, "project_uid", projectUID)
 		return nil
 	}
-	if result.InviteUID == "" {
-		// Defensive: infra-layer SendInviteRequest validates this, but guard here too.
-		slog.WarnContext(ctx, "project_subscriber: invite service responded without an invite UID — skipping write-back",
-			"role", role, "project_uid", projectUID)
-		return nil
-	}
+	slog.InfoContext(ctx, "project_subscriber: invite sent",
+		"role", role, "project_uid", projectUID, "invite_uid", result.InviteUID)
 
-	slog.InfoContext(ctx, "project_subscriber: invite service responded with invite UID — storing on member record",
-		"role", role, "project_uid", projectUID, "invite_uid", result.InviteUID, "expires_at", result.ExpiresAt)
-
-	if storeErr := s.storeInviteInfo(ctx, projectUID, role, recipientEmail, result.InviteUID, result.RecipientEmail, result.ExpiresAt); storeErr != nil {
-		slog.WarnContext(ctx, "project_subscriber: failed to store invite info on user",
-			constants.ErrKey, storeErr, "role", role, "project_uid", projectUID, "invite_uid", result.InviteUID)
-	}
-	return nil
-}
-
-// storeInviteInfo reads project settings, locates the user by email in the given role's
-// slice, stamps their InviteUID, InviteEmail, and InviteExpiresAt, and writes the settings
-// back using optimistic concurrency. It retries up to 3 times on ErrRevisionMismatch,
-// which can occur when multiple non-LFID users are added in the same event and concurrent
-// write-backs race on the same KV revision.
-func (s *ProjectsService) storeInviteInfo(ctx context.Context, projectUID, role, recipientEmail, inviteUID, inviteEmail string, expiresAt time.Time) error {
-	const maxRetries = 3
-	for attempt := range maxRetries {
-		storeCtx, storeCancel := context.WithTimeout(ctx, notificationTimeout)
-		err := s.tryStoreInviteInfo(storeCtx, projectUID, role, recipientEmail, inviteUID, inviteEmail, expiresAt)
-		storeCancel()
-		if err == nil {
-			return nil
-		}
-		if !errors.Is(err, domain.ErrRevisionMismatch) || attempt == maxRetries-1 {
-			return err
-		}
-		slog.DebugContext(ctx, "project_subscriber: revision mismatch storing invite info — retrying",
-			"attempt", attempt+1, "project_uid", projectUID, "role", role, "invite_uid", inviteUID)
-	}
-	return nil
-}
-
-// roleSlice returns a pointer to the settings slice for the given role,
-// or nil for an unrecognised role.
-func roleSlice(s *models.ProjectSettings, role string) *[]models.UserInfo {
-	switch role {
-	case roleWriter:
-		return &s.Writers
-	case roleAuditor:
-		return &s.Auditors
-	case roleMeetingCoordinator:
-		return &s.MeetingCoordinators
-	}
-	return nil
-}
-
-func (s *ProjectsService) tryStoreInviteInfo(ctx context.Context, projectUID, role, recipientEmail, inviteUID, inviteEmail string, expiresAt time.Time) error {
-	slog.DebugContext(ctx, "project_subscriber: reading project settings to store invite info",
-		"project_uid", projectUID, "role", role, "invite_uid", inviteUID)
-
-	settings, revision, err := s.ProjectRepository.GetProjectSettingsWithRevision(ctx, projectUID)
-	if err != nil {
-		slog.WarnContext(ctx, "project_subscriber: failed to read project settings for invite info write-back",
-			constants.ErrKey, err, "project_uid", projectUID)
-		return err
-	}
-
-	slicePtr := roleSlice(settings, role)
-	if slicePtr == nil {
-		return nil
-	}
-
-	normalizedRecipient := strings.ToLower(strings.TrimSpace(recipientEmail))
-	updated := false
-	for i := range *slicePtr {
-		if strings.ToLower(strings.TrimSpace((*slicePtr)[i].Email)) == normalizedRecipient {
-			inv := &models.InviteInfo{UID: inviteUID, Email: inviteEmail}
-			if !expiresAt.IsZero() {
-				inv.ExpiresAt = &expiresAt
-			}
-			(*slicePtr)[i].Invite = inv
-			updated = true
-			break
-		}
-	}
-	if !updated {
-		slog.WarnContext(ctx, "project_subscriber: user not found in role slice — invite info not stored (user may have been removed)",
-			"project_uid", projectUID, "role", role, "invite_uid", inviteUID)
-		return nil
-	}
-
-	if err := s.ProjectRepository.UpdateProjectSettings(ctx, settings, revision); err != nil {
-		if errors.Is(err, domain.ErrRevisionMismatch) {
-			slog.DebugContext(ctx, "project_subscriber: revision mismatch writing invite info — will retry",
-				"project_uid", projectUID, "role", role, "invite_uid", inviteUID)
-		} else {
-			slog.WarnContext(ctx, "project_subscriber: failed to write invite info back to project settings",
-				constants.ErrKey, err, "project_uid", projectUID, "role", role, "invite_uid", inviteUID)
-		}
-		return err
-	}
-
-	slog.InfoContext(ctx, "project_subscriber: stored invite info on member record",
-		"project_uid", projectUID, "role", role, "invite_uid", inviteUID, "expires_at", expiresAt)
-
-	indexMsg := indexerTypes.IndexerMessageEnvelope{
-		Action:         indexerConstants.ActionUpdated,
-		Data:           *settings,
-		IndexingConfig: settings.IndexingConfig(projectUID),
-	}
-	if indexErr := s.MessageBuilder.SendIndexerMessage(ctx, constants.IndexProjectSettingsSubject, indexMsg, false); indexErr != nil {
-		slog.WarnContext(ctx, "project_subscriber: failed to reindex project settings after storing invite info",
-			constants.ErrKey, indexErr, "project_uid", projectUID, "role", role, "invite_uid", inviteUID)
-	}
 	return nil
 }
 
@@ -537,44 +428,25 @@ func (s *ProjectsService) HandleInviteAccepted(ctx context.Context, msg domain.M
 			return nil
 		}
 
-		// Pass 1: find the entry that owns the invite UID and promote it.
-		// Record the normalised email so sibling entries for the same user can be
-		// promoted in pass 2 (they share an email but were deduplicated and never
-		// received their own invite UID).
+		// Promote all email-only entries that match the recipient email. The invite
+		// service carries the email in the enriched payload so we no longer rely on
+		// a stored invite UID for matching.
 		promoted = false
-		var promotedEmail string
+		normalizedEmail := strings.ToLower(strings.TrimSpace(event.Recipient.Email))
 		allSlices := []*[]models.UserInfo{&settings.Writers, &settings.Auditors, &settings.MeetingCoordinators}
 		for _, slice := range allSlices {
 			for i := range *slice {
-				if (*slice)[i].Invite != nil && (*slice)[i].Invite.UID == event.UID {
-					promotedEmail = strings.ToLower(strings.TrimSpace((*slice)[i].Email))
+				if (*slice)[i].Username == "" && strings.ToLower(strings.TrimSpace((*slice)[i].Email)) == normalizedEmail {
 					(*slice)[i].Username = event.AcceptedBy
-					(*slice)[i].Invite = nil
+					(*slice)[i].Invite = nil // clear any residual invite metadata
 					promoted = true
-					break
-				}
-			}
-			if promoted {
-				break
-			}
-		}
-
-		// Pass 2: promote any sibling entries for the same email that were skipped
-		// during invite deduplication and therefore have no invite UID of their own.
-		if promoted && promotedEmail != "" {
-			for _, slice := range allSlices {
-				for i := range *slice {
-					if (*slice)[i].Username == "" && strings.ToLower(strings.TrimSpace((*slice)[i].Email)) == promotedEmail {
-						(*slice)[i].Username = event.AcceptedBy
-						(*slice)[i].Invite = nil
-					}
 				}
 			}
 		}
 
 		if !promoted {
-			slog.WarnContext(ctx, "project_subscriber: invite UID not found in any role slice — may have already been promoted",
-				"invite_uid", event.UID, "project_uid", projectUID)
+			slog.WarnContext(ctx, "project_subscriber: no email-only entry found for recipient — may have already been promoted",
+				"project_uid", projectUID, "invite_uid", event.UID)
 			return nil
 		}
 

--- a/internal/service/project_subscriber.go
+++ b/internal/service/project_subscriber.go
@@ -393,10 +393,11 @@ func (s *ProjectsService) HandleInviteAccepted(ctx context.Context, msg domain.M
 	}
 
 	normalizedEmail := strings.ToLower(strings.TrimSpace(event.Recipient.Email))
-	if event.UID == "" || event.AcceptedBy == "" || normalizedEmail == "" {
-		slog.WarnContext(ctx, "project_subscriber: invite_accepted event missing required fields — discarding",
+	validRole := event.Role == string(inviteapi.InviteRoleManage) || event.Role == string(inviteapi.InviteRoleView)
+	if event.UID == "" || event.AcceptedBy == "" || normalizedEmail == "" || !validRole {
+		slog.WarnContext(ctx, "project_subscriber: invite_accepted event missing or unrecognized required fields — discarding",
 			"invite_uid", event.UID, "has_accepted_by", event.AcceptedBy != "",
-			"has_recipient_email", normalizedEmail != "")
+			"has_recipient_email", normalizedEmail != "", "role", event.Role)
 		return nil
 	}
 

--- a/internal/service/project_subscriber.go
+++ b/internal/service/project_subscriber.go
@@ -388,17 +388,17 @@ func (s *ProjectsService) HandleInviteAccepted(ctx context.Context, msg domain.M
 		return nil
 	}
 
-	if event.UID == "" || event.AcceptedBy == "" || event.Recipient.Email == "" {
+	normalizedEmail := strings.ToLower(strings.TrimSpace(event.Recipient.Email))
+	if event.UID == "" || event.AcceptedBy == "" || normalizedEmail == "" {
 		slog.WarnContext(ctx, "project_subscriber: invite_accepted event missing required fields — discarding",
-			"invite_uid", event.UID, "accepted_by", event.AcceptedBy, "recipient_email", event.Recipient.Email)
+			"invite_uid", event.UID, "has_accepted_by", event.AcceptedBy != "",
+			"has_recipient_email", normalizedEmail != "")
 		return nil
 	}
 
 	acceptCtx, acceptCancel := context.WithTimeout(ctx, notificationTimeout)
 	defer acceptCancel()
 	ctx = acceptCtx
-
-	normalizedEmail := strings.ToLower(strings.TrimSpace(event.Recipient.Email))
 
 	// Scan all project settings for email-only entries that match the recipient.
 	allSettings, listErr := s.ProjectRepository.ListAllProjectsSettings(ctx)

--- a/internal/service/project_subscriber.go
+++ b/internal/service/project_subscriber.go
@@ -409,21 +409,21 @@ func (s *ProjectsService) HandleInviteAccepted(ctx context.Context, msg domain.M
 	}
 
 	for _, candidate := range allSettings {
-		if !projectSettingsHasEmailOnlyEntry(candidate, normalizedEmail) {
+		if !projectSettingsHasEmailOnlyEntry(candidate, normalizedEmail, event.Role) {
 			continue
 		}
 		projectUID := candidate.UID
-		s.promoteInvitedUserInProjectSettings(ctx, projectUID, normalizedEmail, event.AcceptedBy, event.UID)
+		s.promoteInvitedUserInProjectSettings(ctx, projectUID, normalizedEmail, event.AcceptedBy, event.UID, event.Role)
 	}
 
 	return nil
 }
 
 // projectSettingsHasEmailOnlyEntry reports whether settings contain at least one
-// email-only (non-LFID) entry whose email matches normalizedEmail.
-func projectSettingsHasEmailOnlyEntry(s *models.ProjectSettings, normalizedEmail string) bool {
-	allSlices := [][]models.UserInfo{s.Writers, s.Auditors, s.MeetingCoordinators}
-	for _, slice := range allSlices {
+// email-only (non-LFID) entry whose email matches normalizedEmail, considering only
+// the role-appropriate slices.
+func projectSettingsHasEmailOnlyEntry(s *models.ProjectSettings, normalizedEmail, role string) bool {
+	for _, slice := range projectRoleSlices(s, role) {
 		for _, u := range slice {
 			if u.Username == "" && strings.ToLower(strings.TrimSpace(u.Email)) == normalizedEmail {
 				return true
@@ -433,9 +433,34 @@ func projectSettingsHasEmailOnlyEntry(s *models.ProjectSettings, normalizedEmail
 	return false
 }
 
+// projectRoleSlices returns the settings slices to scan/update for a given invite role.
+// "Manage" → Writers + MeetingCoordinators; "View" → Auditors only; unknown → all three.
+func projectRoleSlices(s *models.ProjectSettings, role string) [][]models.UserInfo {
+	switch role {
+	case string(inviteapi.InviteRoleManage):
+		return [][]models.UserInfo{s.Writers, s.MeetingCoordinators}
+	case string(inviteapi.InviteRoleView):
+		return [][]models.UserInfo{s.Auditors}
+	default:
+		return [][]models.UserInfo{s.Writers, s.Auditors, s.MeetingCoordinators}
+	}
+}
+
+// projectRoleSlicePtrs returns pointer-to-slice refs matching projectRoleSlices, for mutation.
+func projectRoleSlicePtrs(s *models.ProjectSettings, role string) []*[]models.UserInfo {
+	switch role {
+	case string(inviteapi.InviteRoleManage):
+		return []*[]models.UserInfo{&s.Writers, &s.MeetingCoordinators}
+	case string(inviteapi.InviteRoleView):
+		return []*[]models.UserInfo{&s.Auditors}
+	default:
+		return []*[]models.UserInfo{&s.Writers, &s.Auditors, &s.MeetingCoordinators}
+	}
+}
+
 // promoteInvitedUserInProjectSettings promotes all email-only entries matching normalizedEmail
 // in the given project's settings to full LFID users. It retries on revision conflicts.
-func (s *ProjectsService) promoteInvitedUserInProjectSettings(ctx context.Context, projectUID, normalizedEmail, username, inviteUID string) {
+func (s *ProjectsService) promoteInvitedUserInProjectSettings(ctx context.Context, projectUID, normalizedEmail, username, inviteUID, role string) {
 	const maxRetries = 3
 	for attempt := range maxRetries {
 		settings, revision, err := s.ProjectRepository.GetProjectSettingsWithRevision(ctx, projectUID)
@@ -446,8 +471,7 @@ func (s *ProjectsService) promoteInvitedUserInProjectSettings(ctx context.Contex
 		}
 
 		promoted := false
-		allSlices := []*[]models.UserInfo{&settings.Writers, &settings.Auditors, &settings.MeetingCoordinators}
-		for _, slice := range allSlices {
+		for _, slice := range projectRoleSlicePtrs(settings, role) {
 			for i := range *slice {
 				if (*slice)[i].Username == "" && strings.ToLower(strings.TrimSpace((*slice)[i].Email)) == normalizedEmail {
 					(*slice)[i].Username = username

--- a/internal/service/project_subscriber.go
+++ b/internal/service/project_subscriber.go
@@ -396,12 +396,10 @@ func (s *ProjectsService) HandleInviteAccepted(ctx context.Context, msg domain.M
 		return nil
 	}
 
-	acceptCtx, acceptCancel := context.WithTimeout(ctx, notificationTimeout)
-	defer acceptCancel()
-	ctx = acceptCtx
-
 	// Scan all project settings for email-only entries that match the recipient.
-	allSettings, listErr := s.ProjectRepository.ListAllProjectsSettings(ctx)
+	listCtx, listCancel := context.WithTimeout(ctx, notificationTimeout)
+	allSettings, listErr := s.ProjectRepository.ListAllProjectsSettings(listCtx)
+	listCancel()
 	if listErr != nil {
 		slog.WarnContext(ctx, "project_subscriber: failed to list project settings for invite reconciliation",
 			constants.ErrKey, listErr, "invite_uid", event.UID)
@@ -413,7 +411,9 @@ func (s *ProjectsService) HandleInviteAccepted(ctx context.Context, msg domain.M
 			continue
 		}
 		projectUID := candidate.UID
-		s.promoteInvitedUserInProjectSettings(ctx, projectUID, normalizedEmail, event.AcceptedBy, event.UID, event.Role)
+		promoteCtx, promoteCancel := context.WithTimeout(ctx, notificationTimeout)
+		s.promoteInvitedUserInProjectSettings(promoteCtx, projectUID, normalizedEmail, event.AcceptedBy, event.UID, event.Role)
+		promoteCancel()
 	}
 
 	return nil

--- a/internal/service/project_subscriber.go
+++ b/internal/service/project_subscriber.go
@@ -348,13 +348,6 @@ func (s *ProjectsService) tryStoreInviteInfo(ctx context.Context, projectUID, ro
 	slog.InfoContext(ctx, "project_subscriber: stored invite info on member record",
 		"project_uid", projectUID, "role", role, "invite_uid", inviteUID, "expires_at", expiresAt)
 
-	// Write the invite UID → project UID mapping so HandleInviteAccepted can route the
-	// acceptance event without scanning all project settings.
-	if mappingErr := s.ProjectRepository.CreateInviteMapping(ctx, inviteUID, projectUID); mappingErr != nil {
-		slog.WarnContext(ctx, "project_subscriber: failed to create invite mapping — acceptance routing will not work",
-			constants.ErrKey, mappingErr, "project_uid", projectUID, "invite_uid", inviteUID)
-	}
-
 	indexMsg := indexerTypes.IndexerMessageEnvelope{
 		Action:         indexerConstants.ActionUpdated,
 		Data:           *settings,
@@ -490,24 +483,31 @@ func (s *ProjectsService) resolveActorDisplayName(ctx context.Context, actor eve
 	return "A project administrator"
 }
 
-// HandleInviteAccepted processes an invite acceptance event from the LFX self-serve web app.
-// It locates the project settings that own the invite via the mapping written at invite-send time,
-// promotes the user from non-LFID (email-only) to LFID (username set, invite cleared), persists
-// the update, deletes the consumed mapping, and re-indexes.
+// HandleInviteAccepted processes an invite acceptance event published by the invite service.
+// It locates the project settings that own the invite via the resource UID carried in the
+// enriched payload, promotes the user from non-LFID (email-only) to LFID (username set,
+// invite cleared), persists the update, and re-indexes.
 //
 // Note: a single notificationTimeout deadline covers the entire handler body including all retry
 // attempts. If KV contention causes all retries to exhaust the budget, the promotion is lost and
 // the user must re-accept the invite link to trigger a new acceptance event.
 func (s *ProjectsService) HandleInviteAccepted(ctx context.Context, msg domain.Message) error {
-	var event events.InviteAccepted
+	var event inviteapi.InviteServiceAcceptedEvent
 	if err := json.Unmarshal(msg.Data(), &event); err != nil {
 		slog.WarnContext(ctx, "project_subscriber: failed to unmarshal invite_accepted event", constants.ErrKey, err)
 		return nil
 	}
 
-	if event.InviteUID == "" || event.Username == "" {
-		slog.WarnContext(ctx, "project_subscriber: invite_accepted event missing invite_uid or username — discarding",
-			"invite_uid", event.InviteUID, "username", event.Username)
+	if event.UID == "" || event.AcceptedBy == "" {
+		slog.WarnContext(ctx, "project_subscriber: invite_accepted event missing uid or accepted_by — discarding",
+			"invite_uid", event.UID, "accepted_by", event.AcceptedBy)
+		return nil
+	}
+
+	// The invite service publishes this event for all resource types; only process project invites.
+	if event.Resource.Type != "project" {
+		slog.DebugContext(ctx, "project_subscriber: invite not for a project resource — ignoring",
+			"resource_type", event.Resource.Type, "invite_uid", event.UID)
 		return nil
 	}
 
@@ -515,19 +515,7 @@ func (s *ProjectsService) HandleInviteAccepted(ctx context.Context, msg domain.M
 	defer acceptCancel()
 	ctx = acceptCtx
 
-	// Look up the project UID from the mapping.
-	projectUID, err := s.ProjectRepository.GetProjectUIDByInviteUID(ctx, event.InviteUID)
-	if err != nil {
-		if errors.Is(err, domain.ErrInviteMappingNotFound) {
-			// No mapping means this invite belongs to another service — silently ignore.
-			slog.DebugContext(ctx, "project_subscriber: invite not tracked by this service — ignoring",
-				"invite_uid", event.InviteUID)
-			return nil
-		}
-		slog.WarnContext(ctx, "project_subscriber: KV error looking up invite mapping",
-			constants.ErrKey, err, "invite_uid", event.InviteUID)
-		return nil
-	}
+	projectUID := event.Resource.UID
 
 	const maxPromoteRetries = 3
 	var (
@@ -541,11 +529,11 @@ func (s *ProjectsService) HandleInviteAccepted(ctx context.Context, msg domain.M
 		if settingsErr != nil {
 			if attempt < maxPromoteRetries-1 {
 				slog.DebugContext(ctx, "project_subscriber: transient error reading settings for invite acceptance — retrying",
-					constants.ErrKey, settingsErr, "attempt", attempt+1, "project_uid", projectUID, "invite_uid", event.InviteUID)
+					constants.ErrKey, settingsErr, "attempt", attempt+1, "project_uid", projectUID, "invite_uid", event.UID)
 				continue
 			}
 			slog.WarnContext(ctx, "project_subscriber: failed to read settings for invite acceptance",
-				constants.ErrKey, settingsErr, "project_uid", projectUID, "invite_uid", event.InviteUID)
+				constants.ErrKey, settingsErr, "project_uid", projectUID, "invite_uid", event.UID)
 			return nil
 		}
 
@@ -558,9 +546,9 @@ func (s *ProjectsService) HandleInviteAccepted(ctx context.Context, msg domain.M
 		allSlices := []*[]models.UserInfo{&settings.Writers, &settings.Auditors, &settings.MeetingCoordinators}
 		for _, slice := range allSlices {
 			for i := range *slice {
-				if (*slice)[i].Invite != nil && (*slice)[i].Invite.UID == event.InviteUID {
+				if (*slice)[i].Invite != nil && (*slice)[i].Invite.UID == event.UID {
 					promotedEmail = strings.ToLower(strings.TrimSpace((*slice)[i].Email))
-					(*slice)[i].Username = event.Username
+					(*slice)[i].Username = event.AcceptedBy
 					(*slice)[i].Invite = nil
 					promoted = true
 					break
@@ -577,7 +565,7 @@ func (s *ProjectsService) HandleInviteAccepted(ctx context.Context, msg domain.M
 			for _, slice := range allSlices {
 				for i := range *slice {
 					if (*slice)[i].Username == "" && strings.ToLower(strings.TrimSpace((*slice)[i].Email)) == promotedEmail {
-						(*slice)[i].Username = event.Username
+						(*slice)[i].Username = event.AcceptedBy
 						(*slice)[i].Invite = nil
 					}
 				}
@@ -585,11 +573,8 @@ func (s *ProjectsService) HandleInviteAccepted(ctx context.Context, msg domain.M
 		}
 
 		if !promoted {
-			slog.WarnContext(ctx, "project_subscriber: invite UID not found in any role slice — stale mapping, cleaning up",
-				"invite_uid", event.InviteUID, "project_uid", projectUID)
-			if delErr := s.ProjectRepository.DeleteInviteMapping(ctx, event.InviteUID); delErr != nil {
-				slog.WarnContext(ctx, "project_subscriber: failed to delete stale invite mapping", constants.ErrKey, delErr, "invite_uid", event.InviteUID)
-			}
+			slog.WarnContext(ctx, "project_subscriber: invite UID not found in any role slice — may have already been promoted",
+				"invite_uid", event.UID, "project_uid", projectUID)
 			return nil
 		}
 
@@ -599,20 +584,15 @@ func (s *ProjectsService) HandleInviteAccepted(ctx context.Context, msg domain.M
 		}
 		if !errors.Is(updateErr, domain.ErrRevisionMismatch) || attempt == maxPromoteRetries-1 {
 			slog.WarnContext(ctx, "project_subscriber: failed to update settings after invite acceptance",
-				constants.ErrKey, updateErr, "project_uid", projectUID, "invite_uid", event.InviteUID)
+				constants.ErrKey, updateErr, "project_uid", projectUID, "invite_uid", event.UID)
 			return nil
 		}
 		slog.DebugContext(ctx, "project_subscriber: revision mismatch promoting invite — retrying",
-			"attempt", attempt+1, "invite_uid", event.InviteUID)
-	}
-
-	if delErr := s.ProjectRepository.DeleteInviteMapping(ctx, event.InviteUID); delErr != nil {
-		slog.WarnContext(ctx, "project_subscriber: failed to delete invite mapping after acceptance",
-			constants.ErrKey, delErr, "invite_uid", event.InviteUID)
+			"attempt", attempt+1, "invite_uid", event.UID)
 	}
 
 	slog.InfoContext(ctx, "project_subscriber: invite accepted — promoted user from non-LFID to LFID",
-		"project_uid", projectUID, "invite_uid", event.InviteUID, "username", event.Username)
+		"project_uid", projectUID, "invite_uid", event.UID, "username", event.AcceptedBy)
 
 	indexMsg := indexerTypes.IndexerMessageEnvelope{
 		Action:         indexerConstants.ActionUpdated,

--- a/internal/service/project_subscriber.go
+++ b/internal/service/project_subscriber.go
@@ -375,13 +375,12 @@ func (s *ProjectsService) resolveActorDisplayName(ctx context.Context, actor eve
 }
 
 // HandleInviteAccepted processes an invite acceptance event published by the invite service.
-// It locates the project settings that own the invite via the resource UID carried in the
-// enriched payload, promotes the user from non-LFID (email-only) to LFID (username set,
-// invite cleared), persists the update, and re-indexes.
+// It scans all project settings for email-only user entries matching the recipient email and
+// promotes them to full LFID users (username set, invite cleared). This reconciles every
+// project the accepted user was invited to, regardless of which resource triggered the event.
 //
-// Note: a single notificationTimeout deadline covers the entire handler body including all retry
-// attempts. If KV contention causes all retries to exhaust the budget, the promotion is lost and
-// the user must re-accept the invite link to trigger a new acceptance event.
+// TODO: replace the full-scan with an email → [project_uid] index lookup so we avoid reading
+// every project's settings on each acceptance event.
 func (s *ProjectsService) HandleInviteAccepted(ctx context.Context, msg domain.Message) error {
 	var event inviteapi.InviteServiceAcceptedEvent
 	if err := json.Unmarshal(msg.Data(), &event); err != nil {
@@ -389,16 +388,9 @@ func (s *ProjectsService) HandleInviteAccepted(ctx context.Context, msg domain.M
 		return nil
 	}
 
-	if event.UID == "" || event.AcceptedBy == "" {
-		slog.WarnContext(ctx, "project_subscriber: invite_accepted event missing uid or accepted_by — discarding",
-			"invite_uid", event.UID, "accepted_by", event.AcceptedBy)
-		return nil
-	}
-
-	// The invite service publishes this event for all resource types; only process project invites.
-	if event.Resource.Type != "project" {
-		slog.DebugContext(ctx, "project_subscriber: invite not for a project resource — ignoring",
-			"resource_type", event.Resource.Type, "invite_uid", event.UID)
+	if event.UID == "" || event.AcceptedBy == "" || event.Recipient.Email == "" {
+		slog.WarnContext(ctx, "project_subscriber: invite_accepted event missing required fields — discarding",
+			"invite_uid", event.UID, "accepted_by", event.AcceptedBy, "recipient_email", event.Recipient.Email)
 		return nil
 	}
 
@@ -406,77 +398,95 @@ func (s *ProjectsService) HandleInviteAccepted(ctx context.Context, msg domain.M
 	defer acceptCancel()
 	ctx = acceptCtx
 
-	projectUID := event.Resource.UID
+	normalizedEmail := strings.ToLower(strings.TrimSpace(event.Recipient.Email))
 
-	const maxPromoteRetries = 3
-	var (
-		settings *models.ProjectSettings
-		promoted bool
-	)
-	for attempt := range maxPromoteRetries {
-		var revision uint64
-		var settingsErr error
-		settings, revision, settingsErr = s.ProjectRepository.GetProjectSettingsWithRevision(ctx, projectUID)
-		if settingsErr != nil {
-			if attempt < maxPromoteRetries-1 {
-				slog.DebugContext(ctx, "project_subscriber: transient error reading settings for invite acceptance — retrying",
-					constants.ErrKey, settingsErr, "attempt", attempt+1, "project_uid", projectUID, "invite_uid", event.UID)
-				continue
+	// Scan all project settings for email-only entries that match the recipient.
+	allSettings, listErr := s.ProjectRepository.ListAllProjectsSettings(ctx)
+	if listErr != nil {
+		slog.WarnContext(ctx, "project_subscriber: failed to list project settings for invite reconciliation",
+			constants.ErrKey, listErr, "invite_uid", event.UID)
+		return nil
+	}
+
+	for _, candidate := range allSettings {
+		if !projectSettingsHasEmailOnlyEntry(candidate, normalizedEmail) {
+			continue
+		}
+		projectUID := candidate.UID
+		s.promoteInvitedUserInProjectSettings(ctx, projectUID, normalizedEmail, event.AcceptedBy, event.UID)
+	}
+
+	return nil
+}
+
+// projectSettingsHasEmailOnlyEntry reports whether settings contain at least one
+// email-only (non-LFID) entry whose email matches normalizedEmail.
+func projectSettingsHasEmailOnlyEntry(s *models.ProjectSettings, normalizedEmail string) bool {
+	allSlices := [][]models.UserInfo{s.Writers, s.Auditors, s.MeetingCoordinators}
+	for _, slice := range allSlices {
+		for _, u := range slice {
+			if u.Username == "" && strings.ToLower(strings.TrimSpace(u.Email)) == normalizedEmail {
+				return true
 			}
-			slog.WarnContext(ctx, "project_subscriber: failed to read settings for invite acceptance",
-				constants.ErrKey, settingsErr, "project_uid", projectUID, "invite_uid", event.UID)
-			return nil
+		}
+	}
+	return false
+}
+
+// promoteInvitedUserInProjectSettings promotes all email-only entries matching normalizedEmail
+// in the given project's settings to full LFID users. It retries on revision conflicts.
+func (s *ProjectsService) promoteInvitedUserInProjectSettings(ctx context.Context, projectUID, normalizedEmail, username, inviteUID string) {
+	const maxRetries = 3
+	for attempt := range maxRetries {
+		settings, revision, err := s.ProjectRepository.GetProjectSettingsWithRevision(ctx, projectUID)
+		if err != nil {
+			slog.WarnContext(ctx, "project_subscriber: failed to read settings for invite promotion",
+				constants.ErrKey, err, "project_uid", projectUID, "invite_uid", inviteUID)
+			return
 		}
 
-		// Promote all email-only entries that match the recipient email. The invite
-		// service carries the email in the enriched payload so we no longer rely on
-		// a stored invite UID for matching.
-		promoted = false
-		normalizedEmail := strings.ToLower(strings.TrimSpace(event.Recipient.Email))
+		promoted := false
 		allSlices := []*[]models.UserInfo{&settings.Writers, &settings.Auditors, &settings.MeetingCoordinators}
 		for _, slice := range allSlices {
 			for i := range *slice {
 				if (*slice)[i].Username == "" && strings.ToLower(strings.TrimSpace((*slice)[i].Email)) == normalizedEmail {
-					(*slice)[i].Username = event.AcceptedBy
-					(*slice)[i].Invite = nil // clear any residual invite metadata
+					(*slice)[i].Username = username
+					(*slice)[i].Invite = nil
 					promoted = true
 				}
 			}
 		}
 
 		if !promoted {
-			slog.WarnContext(ctx, "project_subscriber: no email-only entry found for recipient — may have already been promoted",
-				"project_uid", projectUID, "invite_uid", event.UID)
-			return nil
+			// Race: another handler already promoted this entry between the scan and now.
+			slog.DebugContext(ctx, "project_subscriber: email-only entry already promoted — skipping",
+				"project_uid", projectUID, "invite_uid", inviteUID)
+			return
 		}
 
 		updateErr := s.ProjectRepository.UpdateProjectSettings(ctx, settings, revision)
 		if updateErr == nil {
-			break
+			slog.InfoContext(ctx, "project_subscriber: invite accepted — promoted user from non-LFID to LFID",
+				"project_uid", projectUID, "invite_uid", inviteUID, "username", username)
+			indexMsg := indexerTypes.IndexerMessageEnvelope{
+				Action:         indexerConstants.ActionUpdated,
+				Data:           *settings,
+				IndexingConfig: settings.IndexingConfig(projectUID),
+			}
+			if indexErr := s.MessageBuilder.SendIndexerMessage(ctx, constants.IndexProjectSettingsSubject, indexMsg, false); indexErr != nil {
+				slog.WarnContext(ctx, "project_subscriber: failed to reindex project settings after invite acceptance",
+					constants.ErrKey, indexErr, "project_uid", projectUID)
+			}
+			return
 		}
-		if !errors.Is(updateErr, domain.ErrRevisionMismatch) || attempt == maxPromoteRetries-1 {
+		if !errors.Is(updateErr, domain.ErrRevisionMismatch) || attempt == maxRetries-1 {
 			slog.WarnContext(ctx, "project_subscriber: failed to update settings after invite acceptance",
-				constants.ErrKey, updateErr, "project_uid", projectUID, "invite_uid", event.UID)
-			return nil
+				constants.ErrKey, updateErr, "project_uid", projectUID, "invite_uid", inviteUID)
+			return
 		}
 		slog.DebugContext(ctx, "project_subscriber: revision mismatch promoting invite — retrying",
-			"attempt", attempt+1, "invite_uid", event.UID)
+			"attempt", attempt+1, "project_uid", projectUID, "invite_uid", inviteUID)
 	}
-
-	slog.InfoContext(ctx, "project_subscriber: invite accepted — promoted user from non-LFID to LFID",
-		"project_uid", projectUID, "invite_uid", event.UID, "username", event.AcceptedBy)
-
-	indexMsg := indexerTypes.IndexerMessageEnvelope{
-		Action:         indexerConstants.ActionUpdated,
-		Data:           *settings,
-		IndexingConfig: settings.IndexingConfig(projectUID),
-	}
-	if indexErr := s.MessageBuilder.SendIndexerMessage(ctx, constants.IndexProjectSettingsSubject, indexMsg, false); indexErr != nil {
-		slog.WarnContext(ctx, "project_subscriber: failed to reindex project settings after invite acceptance",
-			constants.ErrKey, indexErr, "project_uid", projectUID)
-	}
-
-	return nil
 }
 
 // buildProjectURL constructs the deep-link URL for a project's overview page.

--- a/internal/service/project_subscriber.go
+++ b/internal/service/project_subscriber.go
@@ -224,12 +224,18 @@ func (s *ProjectsService) sendInvite(ctx context.Context, projectUID, projectNam
 	defer cancel()
 
 	result, err := s.MessageBuilder.SendInviteRequest(sendCtx, inviteapi.SendInviteRequest{
-		RecipientEmail: recipientEmail,
-		RecipientName:  recipientName,
-		InviterName:    inviterName,
-		ResourceUID:    projectUID,
-		ResourceName:   projectName,
-		ResourceType:   "project",
+		Recipient: &inviteapi.Recipient{
+			Email: recipientEmail,
+			Name:  recipientName,
+		},
+		Inviter: &inviteapi.Inviter{
+			Name: inviterName,
+		},
+		Resource: &inviteapi.Resource{
+			UID:  projectUID,
+			Name: projectName,
+			Type: "project",
+		},
 		Role:           inviteRole,
 		ReturnURL:      deepLinkURL,
 		ExpirationDays: 30,

--- a/internal/service/project_subscriber.go
+++ b/internal/service/project_subscriber.go
@@ -379,6 +379,10 @@ func (s *ProjectsService) resolveActorDisplayName(ctx context.Context, actor eve
 // promotes them to full LFID users (username set, invite cleared). This reconciles every
 // project the accepted user was invited to, regardless of which resource triggered the event.
 //
+// Note: accepting a single invite reconciles every project where the same email has a
+// pending email-only entry for the same role, not only the project that issued the invite.
+// This is intentional and idempotent.
+//
 // TODO: replace the full-scan with an email → [project_uid] index lookup so we avoid reading
 // every project's settings on each acceptance event.
 func (s *ProjectsService) HandleInviteAccepted(ctx context.Context, msg domain.Message) error {
@@ -433,20 +437,8 @@ func projectSettingsHasEmailOnlyEntry(s *models.ProjectSettings, normalizedEmail
 	return false
 }
 
-// projectRoleSlices returns the settings slices to scan/update for a given invite role.
-// "Manage" → Writers + MeetingCoordinators; "View" → Auditors only; unknown → all three.
-func projectRoleSlices(s *models.ProjectSettings, role string) [][]models.UserInfo {
-	switch role {
-	case string(inviteapi.InviteRoleManage):
-		return [][]models.UserInfo{s.Writers, s.MeetingCoordinators}
-	case string(inviteapi.InviteRoleView):
-		return [][]models.UserInfo{s.Auditors}
-	default:
-		return [][]models.UserInfo{s.Writers, s.Auditors, s.MeetingCoordinators}
-	}
-}
-
-// projectRoleSlicePtrs returns pointer-to-slice refs matching projectRoleSlices, for mutation.
+// projectRoleSlicePtrs returns pointer-to-slice refs for mutation for a given invite role.
+// "Manage" → Writers + MeetingCoordinators; "View" → Auditors only; unknown → nil (fail closed).
 func projectRoleSlicePtrs(s *models.ProjectSettings, role string) []*[]models.UserInfo {
 	switch role {
 	case string(inviteapi.InviteRoleManage):
@@ -454,8 +446,22 @@ func projectRoleSlicePtrs(s *models.ProjectSettings, role string) []*[]models.Us
 	case string(inviteapi.InviteRoleView):
 		return []*[]models.UserInfo{&s.Auditors}
 	default:
-		return []*[]models.UserInfo{&s.Writers, &s.Auditors, &s.MeetingCoordinators}
+		return nil // unknown/unrecognized role — fail closed, do not promote into any slice
 	}
+}
+
+// projectRoleSlices returns the settings slices to scan for a given invite role.
+// Derived from projectRoleSlicePtrs so role mappings cannot drift between the two.
+func projectRoleSlices(s *models.ProjectSettings, role string) [][]models.UserInfo {
+	ptrs := projectRoleSlicePtrs(s, role)
+	if ptrs == nil {
+		return nil
+	}
+	slices := make([][]models.UserInfo, len(ptrs))
+	for i, p := range ptrs {
+		slices[i] = *p
+	}
+	return slices
 }
 
 // promoteInvitedUserInProjectSettings promotes all email-only entries matching normalizedEmail

--- a/internal/service/project_subscriber_test.go
+++ b/internal/service/project_subscriber_test.go
@@ -594,9 +594,11 @@ func TestHandleProjectSettingsUpdated(t *testing.T) {
 				inviteReturnUID := tt.inviteUID
 				inviteReturnErr := tt.msgBuilderErr
 				mockMsg.On("SendInviteRequest", mock.Anything, mock.MatchedBy(func(req inviteapi.SendInviteRequest) bool {
-					return req.ResourceUID == wantProjectUID &&
+					return req.Resource != nil &&
+						req.Resource.UID == wantProjectUID &&
 						(wantRole == "" || req.Role == wantRole) &&
-						req.RecipientEmail != "" &&
+						req.Recipient != nil &&
+						req.Recipient.Email != "" &&
 						req.ReturnURL != ""
 				})).Return(domain.InviteResult{
 					InviteUID:      inviteReturnUID,

--- a/internal/service/project_subscriber_test.go
+++ b/internal/service/project_subscriber_test.go
@@ -6,6 +6,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -1063,6 +1064,63 @@ func TestHandleInviteAccepted(t *testing.T) {
 			},
 			setupMsg: func(m *domain.MockMessageBuilder) {
 				m.On("SendIndexerMessage", mock.Anything, "lfx.index.project_settings", mock.Anything, false).Return(nil)
+			},
+		},
+		{
+			name:    "ListAllProjectsSettings error — early return, no promotion",
+			payload: makeEvent(inviteUID, username, string(inviteapi.InviteRoleManage)),
+			setupRepo: func(r *domain.MockProjectRepository) {
+				r.On("ListAllProjectsSettings", mock.Anything).Return(nil, errors.New("kv unavailable"))
+				// GetProjectSettingsWithRevision and UpdateProjectSettings must NOT be called.
+			},
+		},
+		{
+			name:    "GetProjectSettingsWithRevision error — promotion skipped for that project",
+			payload: makeEvent(inviteUID, username, string(inviteapi.InviteRoleManage)),
+			setupRepo: func(r *domain.MockProjectRepository) {
+				r.On("ListAllProjectsSettings", mock.Anything).Return([]*models.ProjectSettings{makeSettings()}, nil)
+				r.On("GetProjectSettingsWithRevision", mock.Anything, projectUID).Return(nil, uint64(0), errors.New("read failure"))
+				// UpdateProjectSettings must NOT be called.
+			},
+		},
+		{
+			name:    "unknown role — fail closed, no promotion in any slice",
+			payload: makeEvent(inviteUID, username, "unknown-role"),
+			setupRepo: func(r *domain.MockProjectRepository) {
+				// Settings has email in all three slices — none should be promoted.
+				settings := &models.ProjectSettings{
+					UID:                 projectUID,
+					Writers:             []models.UserInfo{{Email: writerEmail}},
+					Auditors:            []models.UserInfo{{Email: writerEmail}},
+					MeetingCoordinators: []models.UserInfo{{Email: writerEmail}},
+				}
+				r.On("ListAllProjectsSettings", mock.Anything).Return([]*models.ProjectSettings{settings}, nil)
+				// GetProjectSettingsWithRevision and UpdateProjectSettings must NOT be called.
+			},
+		},
+		{
+			name:    "multi-project cross-role isolation — View acceptance promotes Auditors in A, leaves Writers in B untouched",
+			payload: makeEvent(inviteUID, username, string(inviteapi.InviteRoleView)),
+			setupRepo: func(r *domain.MockProjectRepository) {
+				// Project A: email is in Auditors (matches View role).
+				settingsA := &models.ProjectSettings{
+					UID:      projectUID,
+					Auditors: []models.UserInfo{{Email: writerEmail}},
+				}
+				// Project B: email is only in Writers (does not match View role — must not be promoted).
+				settingsB := &models.ProjectSettings{
+					UID:     project2UID,
+					Writers: []models.UserInfo{{Email: writerEmail}},
+				}
+				r.On("ListAllProjectsSettings", mock.Anything).Return([]*models.ProjectSettings{settingsA, settingsB}, nil)
+				// Only project A's settings should be read and updated.
+				r.On("GetProjectSettingsWithRevision", mock.Anything, projectUID).Return(settingsA, uint64(1), nil)
+				r.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
+					return len(s.Auditors) > 0 && s.Auditors[0].Username == username
+				}), uint64(1)).Return(nil)
+			},
+			setupMsg: func(m *domain.MockMessageBuilder) {
+				m.On("SendIndexerMessage", mock.Anything, "lfx.index.project_settings", mock.Anything, false).Return(nil).Once()
 			},
 		},
 	}

--- a/internal/service/project_subscriber_test.go
+++ b/internal/service/project_subscriber_test.go
@@ -1084,19 +1084,10 @@ func TestHandleInviteAccepted(t *testing.T) {
 			},
 		},
 		{
-			name:    "unknown role — fail closed, no promotion in any slice",
+			name:    "unknown role — discarded at guard, no repo calls",
 			payload: makeEvent(inviteUID, username, "unknown-role"),
-			setupRepo: func(r *domain.MockProjectRepository) {
-				// Settings has email in all three slices — none should be promoted.
-				settings := &models.ProjectSettings{
-					UID:                 projectUID,
-					Writers:             []models.UserInfo{{Email: writerEmail}},
-					Auditors:            []models.UserInfo{{Email: writerEmail}},
-					MeetingCoordinators: []models.UserInfo{{Email: writerEmail}},
-				}
-				r.On("ListAllProjectsSettings", mock.Anything).Return([]*models.ProjectSettings{settings}, nil)
-				// GetProjectSettingsWithRevision and UpdateProjectSettings must NOT be called.
-			},
+			// No setupRepo: ListAllProjectsSettings, GetProjectSettingsWithRevision, and
+			// UpdateProjectSettings must NOT be called — the event is rejected at the guard.
 		},
 		{
 			name:    "multi-project cross-role isolation — View acceptance promotes Auditors in A, leaves Writers in B untouched",

--- a/internal/service/project_subscriber_test.go
+++ b/internal/service/project_subscriber_test.go
@@ -913,14 +913,15 @@ func TestHandleInviteAccepted(t *testing.T) {
 	const inviteUID = "inv-abc"
 	const username = "newuser"
 	const projectUID = "proj-1"
+	const project2UID = "proj-2"
 
 	const writerEmail = "writer@example.com"
 
-	makeEvent := func(invUID, acceptedBy, resourceUID, resourceType string) inviteapi.InviteServiceAcceptedEvent {
+	makeEvent := func(invUID, acceptedBy string) inviteapi.InviteServiceAcceptedEvent {
 		return inviteapi.InviteServiceAcceptedEvent{Invite: inviteapi.Invite{
 			UID:        invUID,
 			AcceptedBy: acceptedBy,
-			Resource:   inviteapi.Resource{UID: resourceUID, Type: resourceType},
+			Resource:   inviteapi.Resource{UID: "committee-1", Type: "group"},
 			Recipient:  inviteapi.Recipient{Email: writerEmail},
 		}}
 	}
@@ -962,33 +963,38 @@ func TestHandleInviteAccepted(t *testing.T) {
 		},
 		{
 			name:    "missing uid — discarded",
-			payload: makeEvent("", username, projectUID, "project"),
+			payload: makeEvent("", username),
 		},
 		{
 			name:    "missing accepted_by — discarded",
-			payload: makeEvent(inviteUID, "", projectUID, "project"),
+			payload: makeEvent(inviteUID, ""),
 		},
 		{
-			name:    "wrong resource type — silently ignored",
-			payload: makeEvent(inviteUID, username, "committee-1", "group"),
-		},
-		{
-			name:    "happy path — user promoted by email, indexer called",
-			payload: makeEvent(inviteUID, username, projectUID, "project"),
+			name:    "happy path — user promoted across all matching projects, indexer called per project",
+			payload: makeEvent(inviteUID, username),
 			setupRepo: func(r *domain.MockProjectRepository) {
+				// Two projects both have the invited email; both should be promoted.
+				settings1 := makeSettings()
+				settings2 := &models.ProjectSettings{UID: project2UID, Writers: []models.UserInfo{{Email: writerEmail}}}
+				r.On("ListAllProjectsSettings", mock.Anything).Return([]*models.ProjectSettings{settings1, settings2}, nil)
 				r.On("GetProjectSettingsWithRevision", mock.Anything, projectUID).Return(makeSettings(), uint64(1), nil)
+				r.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
+					return len(s.Writers) > 0 && s.Writers[0].Username == username
+				}), uint64(1)).Return(nil)
+				r.On("GetProjectSettingsWithRevision", mock.Anything, project2UID).Return(settings2, uint64(1), nil)
 				r.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
 					return len(s.Writers) > 0 && s.Writers[0].Username == username
 				}), uint64(1)).Return(nil)
 			},
 			setupMsg: func(m *domain.MockMessageBuilder) {
-				m.On("SendIndexerMessage", mock.Anything, "lfx.index.project_settings", indexMatcher, false).Return(nil)
+				m.On("SendIndexerMessage", mock.Anything, "lfx.index.project_settings", indexMatcher, false).Return(nil).Times(2)
 			},
 		},
 		{
 			name:    "ErrRevisionMismatch on UPDATE — succeeds on attempt 2",
-			payload: makeEvent(inviteUID, username, projectUID, "project"),
+			payload: makeEvent(inviteUID, username),
 			setupRepo: func(r *domain.MockProjectRepository) {
+				r.On("ListAllProjectsSettings", mock.Anything).Return([]*models.ProjectSettings{makeSettings()}, nil)
 				// First GET + UPDATE fails with revision mismatch; second GET + UPDATE succeeds.
 				r.On("GetProjectSettingsWithRevision", mock.Anything, projectUID).
 					Return(makeSettings(), uint64(1), nil).Once()
@@ -1006,13 +1012,14 @@ func TestHandleInviteAccepted(t *testing.T) {
 		},
 		{
 			name:    "user in Writer + MC slices — both entries promoted on acceptance",
-			payload: makeEvent(inviteUID, username, projectUID, "project"),
+			payload: makeEvent(inviteUID, username),
 			setupRepo: func(r *domain.MockProjectRepository) {
 				settings := &models.ProjectSettings{
 					UID:                 projectUID,
 					Writers:             []models.UserInfo{{Email: writerEmail}},
 					MeetingCoordinators: []models.UserInfo{{Email: writerEmail}},
 				}
+				r.On("ListAllProjectsSettings", mock.Anything).Return([]*models.ProjectSettings{settings}, nil)
 				r.On("GetProjectSettingsWithRevision", mock.Anything, projectUID).Return(settings, uint64(1), nil)
 				r.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
 					writerOK := len(s.Writers) > 0 && s.Writers[0].Username == username
@@ -1025,12 +1032,13 @@ func TestHandleInviteAccepted(t *testing.T) {
 			},
 		},
 		{
-			name:    "promoted == false (invite already promoted) — warn logged, nil returned",
-			payload: makeEvent(inviteUID, username, projectUID, "project"),
+			name:    "no matching email in any project — no update called",
+			payload: makeEvent(inviteUID, username),
 			setupRepo: func(r *domain.MockProjectRepository) {
-				// Settings contain no entry with the invite UID.
-				r.On("GetProjectSettingsWithRevision", mock.Anything, projectUID).
-					Return(&models.ProjectSettings{UID: projectUID, Writers: []models.UserInfo{{Email: "other@example.com"}}}, uint64(1), nil)
+				// Scan returns settings with a different email — no promotion.
+				r.On("ListAllProjectsSettings", mock.Anything).Return([]*models.ProjectSettings{
+					{UID: projectUID, Writers: []models.UserInfo{{Email: "other@example.com"}}},
+				}, nil)
 			},
 		},
 	}

--- a/internal/service/project_subscriber_test.go
+++ b/internal/service/project_subscriber_test.go
@@ -151,7 +151,6 @@ func TestHandleProjectSettingsUpdated(t *testing.T) {
 				r.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
 					return len(s.Writers) > 0 && s.Writers[0].Invite.UID == "invite-writer-uid"
 				}), uint64(1)).Return(nil)
-				r.On("CreateInviteMapping", mock.Anything, "invite-writer-uid", "proj-1").Return(nil)
 			},
 		},
 		{
@@ -173,7 +172,6 @@ func TestHandleProjectSettingsUpdated(t *testing.T) {
 				r.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
 					return len(s.Auditors) > 0 && s.Auditors[0].Invite.UID == "invite-auditor-uid"
 				}), uint64(1)).Return(nil)
-				r.On("CreateInviteMapping", mock.Anything, "invite-auditor-uid", "proj-1").Return(nil)
 			},
 		},
 		{
@@ -195,7 +193,6 @@ func TestHandleProjectSettingsUpdated(t *testing.T) {
 				r.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
 					return len(s.MeetingCoordinators) > 0 && s.MeetingCoordinators[0].Invite.UID == "invite-mc-uid"
 				}), uint64(1)).Return(nil)
-				r.On("CreateInviteMapping", mock.Anything, "invite-mc-uid", "proj-1").Return(nil)
 			},
 		},
 		{
@@ -332,7 +329,6 @@ func TestHandleProjectSettingsUpdated(t *testing.T) {
 					}
 					return true
 				}), uint64(1)).Return(nil)
-				r.On("CreateInviteMapping", mock.Anything, "invite-writer-uid", "proj-1").Return(nil)
 			},
 		},
 		// ── Error & edge-case cases ───────────────────────────────────────────────────
@@ -1008,6 +1004,14 @@ func TestHandleInviteAccepted(t *testing.T) {
 	const username = "newuser"
 	const projectUID = "proj-1"
 
+	makeEvent := func(invUID, acceptedBy, resourceUID, resourceType string) inviteapi.InviteServiceAcceptedEvent {
+		return inviteapi.InviteServiceAcceptedEvent{Invite: inviteapi.Invite{
+			UID:        invUID,
+			AcceptedBy: acceptedBy,
+			Resource:   inviteapi.Resource{UID: resourceUID, Type: resourceType},
+		}}
+	}
+
 	makeSettings := func() *models.ProjectSettings {
 		return &models.ProjectSettings{
 			UID:     projectUID,
@@ -1044,39 +1048,25 @@ func TestHandleInviteAccepted(t *testing.T) {
 			payload: []byte("not json"),
 		},
 		{
-			name:    "missing invite_uid — discarded",
-			payload: events.InviteAccepted{InviteUID: "", Username: username},
+			name:    "missing uid — discarded",
+			payload: makeEvent("", username, projectUID, "project"),
 		},
 		{
-			name:    "missing username — discarded",
-			payload: events.InviteAccepted{InviteUID: inviteUID, Username: ""},
+			name:    "missing accepted_by — discarded",
+			payload: makeEvent(inviteUID, "", projectUID, "project"),
 		},
 		{
-			name:    "ErrInviteMappingNotFound — silently ignored (debug log, no warn)",
-			payload: events.InviteAccepted{InviteUID: inviteUID, Username: username},
+			name:    "wrong resource type — silently ignored",
+			payload: makeEvent(inviteUID, username, "committee-1", "group"),
+		},
+		{
+			name:    "happy path — user promoted, indexer called",
+			payload: makeEvent(inviteUID, username, projectUID, "project"),
 			setupRepo: func(r *domain.MockProjectRepository) {
-				r.On("GetProjectUIDByInviteUID", mock.Anything, inviteUID).
-					Return("", domain.ErrInviteMappingNotFound)
-			},
-		},
-		{
-			name:    "KV error on GetProjectUIDByInviteUID — warn logged, nil returned",
-			payload: events.InviteAccepted{InviteUID: inviteUID, Username: username},
-			setupRepo: func(r *domain.MockProjectRepository) {
-				r.On("GetProjectUIDByInviteUID", mock.Anything, inviteUID).
-					Return("", assert.AnError)
-			},
-		},
-		{
-			name:    "happy path — user promoted, mapping deleted, indexer called",
-			payload: events.InviteAccepted{InviteUID: inviteUID, Username: username},
-			setupRepo: func(r *domain.MockProjectRepository) {
-				r.On("GetProjectUIDByInviteUID", mock.Anything, inviteUID).Return(projectUID, nil)
 				r.On("GetProjectSettingsWithRevision", mock.Anything, projectUID).Return(makeSettings(), uint64(1), nil)
 				r.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
 					return len(s.Writers) > 0 && s.Writers[0].Username == username && s.Writers[0].Invite == nil
 				}), uint64(1)).Return(nil)
-				r.On("DeleteInviteMapping", mock.Anything, inviteUID).Return(nil)
 			},
 			setupMsg: func(m *domain.MockMessageBuilder) {
 				m.On("SendIndexerMessage", mock.Anything, "lfx.index.project_settings", indexMatcher, false).Return(nil)
@@ -1084,9 +1074,8 @@ func TestHandleInviteAccepted(t *testing.T) {
 		},
 		{
 			name:    "ErrRevisionMismatch on UPDATE — succeeds on attempt 2",
-			payload: events.InviteAccepted{InviteUID: inviteUID, Username: username},
+			payload: makeEvent(inviteUID, username, projectUID, "project"),
 			setupRepo: func(r *domain.MockProjectRepository) {
-				r.On("GetProjectUIDByInviteUID", mock.Anything, inviteUID).Return(projectUID, nil)
 				// First GET + UPDATE fails with revision mismatch; second GET + UPDATE succeeds.
 				r.On("GetProjectSettingsWithRevision", mock.Anything, projectUID).
 					Return(makeSettings(), uint64(1), nil).Once()
@@ -1097,7 +1086,6 @@ func TestHandleInviteAccepted(t *testing.T) {
 				r.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
 					return len(s.Writers) > 0 && s.Writers[0].Username == username && s.Writers[0].Invite == nil
 				}), uint64(2)).Return(nil).Once()
-				r.On("DeleteInviteMapping", mock.Anything, inviteUID).Return(nil)
 			},
 			setupMsg: func(m *domain.MockMessageBuilder) {
 				m.On("SendIndexerMessage", mock.Anything, "lfx.index.project_settings", indexMatcher, false).Return(nil)
@@ -1105,9 +1093,8 @@ func TestHandleInviteAccepted(t *testing.T) {
 		},
 		{
 			name:    "user in Writer + MC slices — both entries promoted on acceptance",
-			payload: events.InviteAccepted{InviteUID: inviteUID, Username: username},
+			payload: makeEvent(inviteUID, username, projectUID, "project"),
 			setupRepo: func(r *domain.MockProjectRepository) {
-				r.On("GetProjectUIDByInviteUID", mock.Anything, inviteUID).Return(projectUID, nil)
 				// Writer has the invite UID; MC is the same user but was deduped (no UID).
 				settings := &models.ProjectSettings{
 					UID:                 projectUID,
@@ -1120,34 +1107,18 @@ func TestHandleInviteAccepted(t *testing.T) {
 					mcOK := len(s.MeetingCoordinators) > 0 && s.MeetingCoordinators[0].Username == username
 					return writerOK && mcOK
 				}), uint64(1)).Return(nil)
-				r.On("DeleteInviteMapping", mock.Anything, inviteUID).Return(nil)
 			},
 			setupMsg: func(m *domain.MockMessageBuilder) {
 				m.On("SendIndexerMessage", mock.Anything, "lfx.index.project_settings", mock.Anything, false).Return(nil)
 			},
 		},
 		{
-			name:    "promoted == false (stale mapping) — mapping deleted, nil returned",
-			payload: events.InviteAccepted{InviteUID: inviteUID, Username: username},
+			name:    "promoted == false (invite already promoted) — warn logged, nil returned",
+			payload: makeEvent(inviteUID, username, projectUID, "project"),
 			setupRepo: func(r *domain.MockProjectRepository) {
-				r.On("GetProjectUIDByInviteUID", mock.Anything, inviteUID).Return(projectUID, nil)
 				// Settings contain no entry with the invite UID.
 				r.On("GetProjectSettingsWithRevision", mock.Anything, projectUID).
 					Return(&models.ProjectSettings{UID: projectUID, Writers: []models.UserInfo{{Email: "other@example.com"}}}, uint64(1), nil)
-				r.On("DeleteInviteMapping", mock.Anything, inviteUID).Return(nil)
-			},
-		},
-		{
-			name:    "mapping-delete failure after acceptance — warn logged, not fatal",
-			payload: events.InviteAccepted{InviteUID: inviteUID, Username: username},
-			setupRepo: func(r *domain.MockProjectRepository) {
-				r.On("GetProjectUIDByInviteUID", mock.Anything, inviteUID).Return(projectUID, nil)
-				r.On("GetProjectSettingsWithRevision", mock.Anything, projectUID).Return(makeSettings(), uint64(1), nil)
-				r.On("UpdateProjectSettings", mock.Anything, mock.Anything, uint64(1)).Return(nil)
-				r.On("DeleteInviteMapping", mock.Anything, inviteUID).Return(assert.AnError)
-			},
-			setupMsg: func(m *domain.MockMessageBuilder) {
-				m.On("SendIndexerMessage", mock.Anything, "lfx.index.project_settings", indexMatcher, false).Return(nil)
 			},
 		},
 	}
@@ -1210,12 +1181,11 @@ func TestStoreInviteInfo(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			name: "happy path — invite info stamped and mapping created",
+			name: "happy path — invite info stamped",
 			setupRepo: func(r *domain.MockProjectRepository) {
 				s, rev := makeSettings(1)
 				r.On("GetProjectSettingsWithRevision", mock.Anything, projectUID).Return(s, rev, nil)
 				r.On("UpdateProjectSettings", mock.Anything, inviteMatcher, rev).Return(nil)
-				r.On("CreateInviteMapping", mock.Anything, inviteUID, projectUID).Return(nil)
 			},
 			setupMsg: func(m *domain.MockMessageBuilder) {
 				m.On("SendIndexerMessage", mock.Anything, "lfx.index.project_settings", mock.Anything, false).Return(nil)
@@ -1233,7 +1203,6 @@ func TestStoreInviteInfo(t *testing.T) {
 				r.On("UpdateProjectSettings", mock.Anything, mock.Anything, uint64(2)).Return(domain.ErrRevisionMismatch).Once()
 				r.On("GetProjectSettingsWithRevision", mock.Anything, projectUID).Return(s3, uint64(3), nil).Once()
 				r.On("UpdateProjectSettings", mock.Anything, inviteMatcher, uint64(3)).Return(nil).Once()
-				r.On("CreateInviteMapping", mock.Anything, inviteUID, projectUID).Return(nil)
 			},
 			setupMsg: func(m *domain.MockMessageBuilder) {
 				m.On("SendIndexerMessage", mock.Anything, "lfx.index.project_settings", mock.Anything, false).Return(nil)

--- a/internal/service/project_subscriber_test.go
+++ b/internal/service/project_subscriber_test.go
@@ -917,10 +917,11 @@ func TestHandleInviteAccepted(t *testing.T) {
 
 	const writerEmail = "writer@example.com"
 
-	makeEvent := func(invUID, acceptedBy string) inviteapi.InviteServiceAcceptedEvent {
+	makeEvent := func(invUID, acceptedBy, role string) inviteapi.InviteServiceAcceptedEvent {
 		return inviteapi.InviteServiceAcceptedEvent{Invite: inviteapi.Invite{
 			UID:        invUID,
 			AcceptedBy: acceptedBy,
+			Role:       role,
 			Resource:   inviteapi.Resource{UID: "committee-1", Type: "group"},
 			Recipient:  inviteapi.Recipient{Email: writerEmail},
 		}}
@@ -963,15 +964,15 @@ func TestHandleInviteAccepted(t *testing.T) {
 		},
 		{
 			name:    "missing uid — discarded",
-			payload: makeEvent("", username),
+			payload: makeEvent("", username, string(inviteapi.InviteRoleManage)),
 		},
 		{
 			name:    "missing accepted_by — discarded",
-			payload: makeEvent(inviteUID, ""),
+			payload: makeEvent(inviteUID, "", string(inviteapi.InviteRoleManage)),
 		},
 		{
 			name:    "happy path — user promoted across all matching projects, indexer called per project",
-			payload: makeEvent(inviteUID, username),
+			payload: makeEvent(inviteUID, username, string(inviteapi.InviteRoleManage)),
 			setupRepo: func(r *domain.MockProjectRepository) {
 				// Two projects both have the invited email; both should be promoted.
 				settings1 := makeSettings()
@@ -992,7 +993,7 @@ func TestHandleInviteAccepted(t *testing.T) {
 		},
 		{
 			name:    "ErrRevisionMismatch on UPDATE — succeeds on attempt 2",
-			payload: makeEvent(inviteUID, username),
+			payload: makeEvent(inviteUID, username, string(inviteapi.InviteRoleManage)),
 			setupRepo: func(r *domain.MockProjectRepository) {
 				r.On("ListAllProjectsSettings", mock.Anything).Return([]*models.ProjectSettings{makeSettings()}, nil)
 				// First GET + UPDATE fails with revision mismatch; second GET + UPDATE succeeds.
@@ -1012,7 +1013,7 @@ func TestHandleInviteAccepted(t *testing.T) {
 		},
 		{
 			name:    "user in Writer + MC slices — both entries promoted on acceptance",
-			payload: makeEvent(inviteUID, username),
+			payload: makeEvent(inviteUID, username, string(inviteapi.InviteRoleManage)),
 			setupRepo: func(r *domain.MockProjectRepository) {
 				settings := &models.ProjectSettings{
 					UID:                 projectUID,
@@ -1033,12 +1034,35 @@ func TestHandleInviteAccepted(t *testing.T) {
 		},
 		{
 			name:    "no matching email in any project — no update called",
-			payload: makeEvent(inviteUID, username),
+			payload: makeEvent(inviteUID, username, string(inviteapi.InviteRoleManage)),
 			setupRepo: func(r *domain.MockProjectRepository) {
 				// Scan returns settings with a different email — no promotion.
 				r.On("ListAllProjectsSettings", mock.Anything).Return([]*models.ProjectSettings{
 					{UID: projectUID, Writers: []models.UserInfo{{Email: "other@example.com"}}},
 				}, nil)
+			},
+		},
+		{
+			name:    "View role — only Auditors promoted, Writers untouched",
+			payload: makeEvent(inviteUID, username, string(inviteapi.InviteRoleView)),
+			setupRepo: func(r *domain.MockProjectRepository) {
+				// Project has both a pending Writer and a pending Auditor entry for the same email.
+				// Accepting a View invite must promote only the Auditor entry.
+				settings := &models.ProjectSettings{
+					UID:      projectUID,
+					Writers:  []models.UserInfo{{Email: writerEmail}},
+					Auditors: []models.UserInfo{{Email: writerEmail}},
+				}
+				r.On("ListAllProjectsSettings", mock.Anything).Return([]*models.ProjectSettings{settings}, nil)
+				r.On("GetProjectSettingsWithRevision", mock.Anything, projectUID).Return(settings, uint64(1), nil)
+				r.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
+					auditorPromoted := len(s.Auditors) > 0 && s.Auditors[0].Username == username
+					writerUnchanged := len(s.Writers) > 0 && s.Writers[0].Username == ""
+					return auditorPromoted && writerUnchanged
+				}), uint64(1)).Return(nil)
+			},
+			setupMsg: func(m *domain.MockMessageBuilder) {
+				m.On("SendIndexerMessage", mock.Anything, "lfx.index.project_settings", mock.Anything, false).Return(nil)
 			},
 		},
 	}

--- a/internal/service/project_subscriber_test.go
+++ b/internal/service/project_subscriber_test.go
@@ -43,27 +43,6 @@ func TestHandleProjectSettingsUpdated(t *testing.T) {
 	noLFIDAuditor := events.UserInfo{Email: "auditor@example.com", Name: "No LFID Auditor"}
 	noLFIDMC := events.UserInfo{Email: "mc@example.com", Name: "No LFID MC"}
 
-	// settingsWithWriter returns a minimal ProjectSettings containing a writer matching the
-	// noLFIDWriter fixture — used to back the GetProjectSettingsWithRevision mock.
-	settingsWithWriter := func() *models.ProjectSettings {
-		return &models.ProjectSettings{
-			UID:     "proj-1",
-			Writers: []models.UserInfo{{Email: noLFIDWriter.Email}},
-		}
-	}
-	settingsWithAuditor := func() *models.ProjectSettings {
-		return &models.ProjectSettings{
-			UID:      "proj-1",
-			Auditors: []models.UserInfo{{Email: noLFIDAuditor.Email}},
-		}
-	}
-	settingsWithMC := func() *models.ProjectSettings {
-		return &models.ProjectSettings{
-			UID:                 "proj-1",
-			MeetingCoordinators: []models.UserInfo{{Email: noLFIDMC.Email}},
-		}
-	}
-
 	tests := []struct {
 		name              string
 		event             events.ProjectSettingsUpdatedMessage
@@ -145,13 +124,6 @@ func TestHandleProjectSettingsUpdated(t *testing.T) {
 			wantInviteCount: 1,
 			wantInviteRole:  string(inviteapi.InviteRoleManage),
 			inviteUID:       "invite-writer-uid",
-			setupRepoExtra: func(r *domain.MockProjectRepository) {
-				r.On("GetProjectSettingsWithRevision", mock.Anything, "proj-1").
-					Return(settingsWithWriter(), uint64(1), nil)
-				r.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
-					return len(s.Writers) > 0 && s.Writers[0].Invite.UID == "invite-writer-uid"
-				}), uint64(1)).Return(nil)
-			},
 		},
 		{
 			name: "non-LFID auditor added — invite request published and invite UID stored",
@@ -166,13 +138,6 @@ func TestHandleProjectSettingsUpdated(t *testing.T) {
 			wantInviteCount: 1,
 			wantInviteRole:  string(inviteapi.InviteRoleView),
 			inviteUID:       "invite-auditor-uid",
-			setupRepoExtra: func(r *domain.MockProjectRepository) {
-				r.On("GetProjectSettingsWithRevision", mock.Anything, "proj-1").
-					Return(settingsWithAuditor(), uint64(1), nil)
-				r.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
-					return len(s.Auditors) > 0 && s.Auditors[0].Invite.UID == "invite-auditor-uid"
-				}), uint64(1)).Return(nil)
-			},
 		},
 		{
 			name: "non-LFID meeting coordinator added — invite request published with Manage role and UID stored",
@@ -187,13 +152,6 @@ func TestHandleProjectSettingsUpdated(t *testing.T) {
 			wantInviteCount: 1,
 			wantInviteRole:  string(inviteapi.InviteRoleManage),
 			inviteUID:       "invite-mc-uid",
-			setupRepoExtra: func(r *domain.MockProjectRepository) {
-				r.On("GetProjectSettingsWithRevision", mock.Anything, "proj-1").
-					Return(settingsWithMC(), uint64(1), nil)
-				r.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
-					return len(s.MeetingCoordinators) > 0 && s.MeetingCoordinators[0].Invite.UID == "invite-mc-uid"
-				}), uint64(1)).Return(nil)
-			},
 		},
 		{
 			name: "mixed LFID and non-LFID added — email for LFID, invite for non-LFID",
@@ -311,25 +269,6 @@ func TestHandleProjectSettingsUpdated(t *testing.T) {
 			wantInviteCount: 1,
 			wantInviteRole:  string(inviteapi.InviteRoleManage),
 			inviteUID:       "invite-writer-uid",
-			setupRepoExtra: func(r *domain.MockProjectRepository) {
-				// Settings contains the user in both slices; only Writers entry should be stamped.
-				r.On("GetProjectSettingsWithRevision", mock.Anything, "proj-1").
-					Return(&models.ProjectSettings{
-						UID:      "proj-1",
-						Writers:  []models.UserInfo{{Email: noLFIDWriter.Email}},
-						Auditors: []models.UserInfo{{Email: noLFIDWriter.Email}},
-					}, uint64(1), nil)
-				r.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
-					if len(s.Writers) == 0 || s.Writers[0].Invite.UID != "invite-writer-uid" {
-						return false
-					}
-					// Auditors entry must NOT have an invite set.
-					if len(s.Auditors) == 0 || s.Auditors[0].Invite != nil {
-						return false
-					}
-					return true
-				}), uint64(1)).Return(nil)
-			},
 		},
 		// ── Error & edge-case cases ───────────────────────────────────────────────────
 		{
@@ -601,35 +540,6 @@ func TestHandleProjectSettingsUpdated(t *testing.T) {
 					RecipientEmail: "nonlfid@example.com",
 					ExpiresAt:      time.Now().Add(30 * 24 * time.Hour),
 				}, inviteReturnErr).Times(tt.wantInviteCount)
-			}
-
-			// Each successful invite write-back triggers a settings reindex.
-			// The matcher verifies the envelope's Data is a ProjectSettings that has
-			// the invite UID set on at least one user in the relevant role slice.
-			wantIndexCount := 0
-			if tt.inviteUID != "" && tt.msgBuilderErr == nil {
-				wantIndexCount = tt.wantInviteCount
-			}
-			if wantIndexCount > 0 {
-				wantInviteUID := tt.inviteUID
-				mockMsg.On("SendIndexerMessage", mock.Anything, "lfx.index.project_settings",
-					mock.MatchedBy(func(msg any) bool {
-						env, ok := msg.(indexerTypes.IndexerMessageEnvelope)
-						if !ok {
-							return false
-						}
-						s, ok := env.Data.(models.ProjectSettings)
-						if !ok {
-							return false
-						}
-						for _, u := range append(append(s.Writers, s.Auditors...), s.MeetingCoordinators...) {
-							if u.Invite != nil && u.Invite.UID == wantInviteUID {
-								return true
-							}
-						}
-						return false
-					}), false).
-					Return(nil).Times(wantIndexCount)
 			}
 
 			if tt.setupRepoExtra != nil {
@@ -1004,18 +914,21 @@ func TestHandleInviteAccepted(t *testing.T) {
 	const username = "newuser"
 	const projectUID = "proj-1"
 
+	const writerEmail = "writer@example.com"
+
 	makeEvent := func(invUID, acceptedBy, resourceUID, resourceType string) inviteapi.InviteServiceAcceptedEvent {
 		return inviteapi.InviteServiceAcceptedEvent{Invite: inviteapi.Invite{
 			UID:        invUID,
 			AcceptedBy: acceptedBy,
 			Resource:   inviteapi.Resource{UID: resourceUID, Type: resourceType},
+			Recipient:  inviteapi.Recipient{Email: writerEmail},
 		}}
 	}
 
 	makeSettings := func() *models.ProjectSettings {
 		return &models.ProjectSettings{
 			UID:     projectUID,
-			Writers: []models.UserInfo{{Email: "writer@example.com", Invite: &models.InviteInfo{UID: inviteUID}}},
+			Writers: []models.UserInfo{{Email: writerEmail}},
 		}
 	}
 
@@ -1029,7 +942,7 @@ func TestHandleInviteAccepted(t *testing.T) {
 			return false
 		}
 		for _, u := range s.Writers {
-			if u.Username == username && u.Invite == nil {
+			if u.Username == username {
 				return true
 			}
 		}
@@ -1060,12 +973,12 @@ func TestHandleInviteAccepted(t *testing.T) {
 			payload: makeEvent(inviteUID, username, "committee-1", "group"),
 		},
 		{
-			name:    "happy path — user promoted, indexer called",
+			name:    "happy path — user promoted by email, indexer called",
 			payload: makeEvent(inviteUID, username, projectUID, "project"),
 			setupRepo: func(r *domain.MockProjectRepository) {
 				r.On("GetProjectSettingsWithRevision", mock.Anything, projectUID).Return(makeSettings(), uint64(1), nil)
 				r.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
-					return len(s.Writers) > 0 && s.Writers[0].Username == username && s.Writers[0].Invite == nil
+					return len(s.Writers) > 0 && s.Writers[0].Username == username
 				}), uint64(1)).Return(nil)
 			},
 			setupMsg: func(m *domain.MockMessageBuilder) {
@@ -1084,7 +997,7 @@ func TestHandleInviteAccepted(t *testing.T) {
 				r.On("GetProjectSettingsWithRevision", mock.Anything, projectUID).
 					Return(makeSettings(), uint64(2), nil).Once()
 				r.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
-					return len(s.Writers) > 0 && s.Writers[0].Username == username && s.Writers[0].Invite == nil
+					return len(s.Writers) > 0 && s.Writers[0].Username == username
 				}), uint64(2)).Return(nil).Once()
 			},
 			setupMsg: func(m *domain.MockMessageBuilder) {
@@ -1095,15 +1008,14 @@ func TestHandleInviteAccepted(t *testing.T) {
 			name:    "user in Writer + MC slices — both entries promoted on acceptance",
 			payload: makeEvent(inviteUID, username, projectUID, "project"),
 			setupRepo: func(r *domain.MockProjectRepository) {
-				// Writer has the invite UID; MC is the same user but was deduped (no UID).
 				settings := &models.ProjectSettings{
 					UID:                 projectUID,
-					Writers:             []models.UserInfo{{Email: "writer@example.com", Invite: &models.InviteInfo{UID: inviteUID}}},
-					MeetingCoordinators: []models.UserInfo{{Email: "writer@example.com"}},
+					Writers:             []models.UserInfo{{Email: writerEmail}},
+					MeetingCoordinators: []models.UserInfo{{Email: writerEmail}},
 				}
 				r.On("GetProjectSettingsWithRevision", mock.Anything, projectUID).Return(settings, uint64(1), nil)
 				r.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
-					writerOK := len(s.Writers) > 0 && s.Writers[0].Username == username && s.Writers[0].Invite == nil
+					writerOK := len(s.Writers) > 0 && s.Writers[0].Username == username
 					mcOK := len(s.MeetingCoordinators) > 0 && s.MeetingCoordinators[0].Username == username
 					return writerOK && mcOK
 				}), uint64(1)).Return(nil)
@@ -1148,106 +1060,6 @@ func TestHandleInviteAccepted(t *testing.T) {
 			msg := domain.NewMockMessage(data, "")
 			err := svc.HandleInviteAccepted(context.Background(), msg)
 			assert.NoError(t, err)
-
-			mockRepo.AssertExpectations(t)
-			mockMsg.AssertExpectations(t)
-		})
-	}
-}
-
-func TestStoreInviteInfo(t *testing.T) {
-	const projectUID = "proj-1"
-	const inviteUID = "inv-xyz"
-	const inviteEmail = "invite@example.com"
-	const recipientEmail = "writer@example.com"
-
-	expiresAt := time.Now().Add(30 * 24 * time.Hour).UTC().Truncate(time.Second)
-
-	makeSettings := func(rev uint64) (*models.ProjectSettings, uint64) {
-		return &models.ProjectSettings{
-			UID:     projectUID,
-			Writers: []models.UserInfo{{Email: recipientEmail}},
-		}, rev
-	}
-
-	inviteMatcher := mock.MatchedBy(func(s *models.ProjectSettings) bool {
-		return len(s.Writers) > 0 && s.Writers[0].Invite != nil && s.Writers[0].Invite.UID == inviteUID
-	})
-
-	tests := []struct {
-		name      string
-		setupRepo func(*domain.MockProjectRepository)
-		setupMsg  func(*domain.MockMessageBuilder)
-		wantErr   bool
-	}{
-		{
-			name: "happy path — invite info stamped",
-			setupRepo: func(r *domain.MockProjectRepository) {
-				s, rev := makeSettings(1)
-				r.On("GetProjectSettingsWithRevision", mock.Anything, projectUID).Return(s, rev, nil)
-				r.On("UpdateProjectSettings", mock.Anything, inviteMatcher, rev).Return(nil)
-			},
-			setupMsg: func(m *domain.MockMessageBuilder) {
-				m.On("SendIndexerMessage", mock.Anything, "lfx.index.project_settings", mock.Anything, false).Return(nil)
-			},
-		},
-		{
-			name: "ErrRevisionMismatch twice then success on attempt 3",
-			setupRepo: func(r *domain.MockProjectRepository) {
-				s1, _ := makeSettings(1)
-				s2, _ := makeSettings(2)
-				s3, _ := makeSettings(3)
-				r.On("GetProjectSettingsWithRevision", mock.Anything, projectUID).Return(s1, uint64(1), nil).Once()
-				r.On("UpdateProjectSettings", mock.Anything, mock.Anything, uint64(1)).Return(domain.ErrRevisionMismatch).Once()
-				r.On("GetProjectSettingsWithRevision", mock.Anything, projectUID).Return(s2, uint64(2), nil).Once()
-				r.On("UpdateProjectSettings", mock.Anything, mock.Anything, uint64(2)).Return(domain.ErrRevisionMismatch).Once()
-				r.On("GetProjectSettingsWithRevision", mock.Anything, projectUID).Return(s3, uint64(3), nil).Once()
-				r.On("UpdateProjectSettings", mock.Anything, inviteMatcher, uint64(3)).Return(nil).Once()
-			},
-			setupMsg: func(m *domain.MockMessageBuilder) {
-				m.On("SendIndexerMessage", mock.Anything, "lfx.index.project_settings", mock.Anything, false).Return(nil)
-			},
-		},
-		{
-			name: "user not found in role slice — no update, no error",
-			setupRepo: func(r *domain.MockProjectRepository) {
-				r.On("GetProjectSettingsWithRevision", mock.Anything, projectUID).Return(&models.ProjectSettings{
-					UID:     projectUID,
-					Writers: []models.UserInfo{{Email: "other@example.com"}},
-				}, uint64(1), nil)
-			},
-		},
-		{
-			name: "KV read error — returned to caller",
-			setupRepo: func(r *domain.MockProjectRepository) {
-				r.On("GetProjectSettingsWithRevision", mock.Anything, projectUID).Return(nil, uint64(0), assert.AnError)
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockRepo := &domain.MockProjectRepository{}
-			mockMsg := &domain.MockMessageBuilder{}
-			if tt.setupRepo != nil {
-				tt.setupRepo(mockRepo)
-			}
-			if tt.setupMsg != nil {
-				tt.setupMsg(mockMsg)
-			}
-
-			svc := &ProjectsService{
-				ProjectRepository: mockRepo,
-				MessageBuilder:    mockMsg,
-			}
-
-			err := svc.storeInviteInfo(context.Background(), projectUID, roleWriter, recipientEmail, inviteUID, inviteEmail, expiresAt)
-			if tt.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
 
 			mockRepo.AssertExpectations(t)
 			mockMsg.AssertExpectations(t)

--- a/pkg/constants/nats.go
+++ b/pkg/constants/nats.go
@@ -32,11 +32,6 @@ const (
 	// KVLookupLinkKey is the per-project link index key.
 	// Format: lookup/project-links/<projectUID>/<linkUID>
 	KVLookupLinkKey = "lookup/project-links/%s/%s"
-
-	// KVLookupInviteMappingPrefix is the mapping key prefix that resolves an invite UID to the
-	// project UID whose settings contain that invite.
-	// Key: "lookup/project-settings-invite/<invite_uid>", Value: <project_uid>
-	KVLookupInviteMappingPrefix = "lookup/project-settings-invite/%s"
 )
 
 // NATS subjects that the project service sends messages about.


### PR DESCRIPTION
## Summary

**1. Migrate `SendInviteRequest` to structured fields**
- Switch invite construction from deprecated scalar fields (`RecipientEmail`, `InviterName`, `ResourceUID`, etc.) to the new structured objects (`Recipient`, `Inviter`, `Resource`)
- Fix response parsing: `SendInviteResponse` embeds `*InviteData` (not a named `Invite` field), so nil-check `resp.InviteData` and read `resp.UID`/`resp.Email`/`resp.ExpiresAt` via embedding
- Bump `lfx-v2-invite-service` dependency to `v0.1.4-0.20260603200146-27b0e0162e1d`

**2. Subscribe to invite-service enriched `invite_accepted` subject**
- Subscribe to `lfx.invite-service.invite_accepted` (published by the invite service after processing) instead of the raw `lfx.invite.accepted` subject
- Use `inviteapi.InviteServiceAcceptedEvent` payload which includes the full `Recipient.Email`, `AcceptedBy`, and `Resource` fields populated by the invite service

**3. Stop storing invite data in project settings user records**
- Remove `InviteUID`, `InviteEmail`, and `InviteExpiresAt` from `UserInfo` in project settings
- `HandleInviteAccepted` no longer matches by invite UID — matching is now done by email against email-only user records (`Username == ""`)

**4. Email-based reconciliation across all project settings**
- On invite acceptance, scan **all** project settings for email-only user entries (`Username == ""`) matching `event.Recipient.Email`
- Promote every matching entry across every project, regardless of which resource type triggered the event (removes the former `Resource.Type == "project"` guard)
- Each project uses a read-check-write retry loop with optimistic locking (3 attempts, retries on `ErrRevisionMismatch`)
- Adds empty-email guard to discard malformed events before scanning
- TODO: replace full scan with an email → `[project_uid]` index for scale

## Ticket

[LFXV2-2079](https://jira.linuxfoundation.org/browse/LFXV2-2079)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2079]: https://linuxfoundation.atlassian.net/browse/LFXV2-2079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ