### PR TITLE
fix: preserve M2M client username when no email present in role fields

### DIFF
--- a/internal/service/project_operations.go
+++ b/internal/service/project_operations.go
@@ -747,8 +747,10 @@ func isCrowdfundingOnly(fundingModels []string) bool {
 // enrichAllRoleFields overwrites Username, Name, and Avatar on every UserInfo across all supplied
 // slices and singles with authoritative values from the auth service.
 // Each unique email is looked up exactly once; lookups run concurrently with a bounded semaphore.
-// Username misses (unknown email, empty email) write an explicit empty-string pointer so the
-// settings converter always overwrites any previously-stored username in the database.
+// Unknown email (ErrUserNotFound) writes an explicit empty-string username so stale LFIDs cannot
+// survive. Missing/empty email skips the auth lookup entirely; the username is cleared to "" only
+// when no username is already present — entries that carry a username but no email (e.g. M2M
+// client principals) are left untouched.
 // Username transport errors fail the request — stale LFIDs must never be silently kept.
 // Metadata (name/avatar) errors only log a warning; display fields do not block the write.
 func (s *ProjectsService) enrichAllRoleFields(
@@ -761,7 +763,8 @@ func (s *ProjectsService) enrichAllRoleFields(
 		return domain.ErrInternal
 	}
 
-	// Gather all entries grouped by email; clear username immediately for entries without an email.
+	// Gather all entries grouped by email; entries without an email skip the lookup — username is
+	// cleared only when none is already set (see function comment for M2M client edge case).
 	type group struct{ users []*projsvc.UserInfo }
 	byEmail := make(map[string]*group)
 
@@ -771,7 +774,10 @@ func (s *ProjectsService) enrichAllRoleFields(
 		}
 		// Treat nil, empty, or whitespace-only emails as missing.
 		if u.Email == nil || strings.TrimSpace(*u.Email) == "" {
-			u.Username = misc.StringPtr("")
+			// No email present — if a username is already set, keep it as-is.
+			if u.Username == nil || strings.TrimSpace(*u.Username) == "" {
+				u.Username = misc.StringPtr("")
+			}
 			return
 		}
 		normEmail := strings.ToLower(strings.TrimSpace(*u.Email))

--- a/internal/service/project_operations_test.go
+++ b/internal/service/project_operations_test.go
@@ -1066,6 +1066,33 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			// Regression: M2M clients have no email but carry a valid username (Auth0 client principal).
+			// The enrichment step must not clear or override the username when no email is present.
+			name: "no email with existing username — M2M client username preserved",
+			payload: &projsvc.UpdateProjectSettingsPayload{
+				UID:     misc.StringPtr("project-uid-1"),
+				IfMatch: misc.StringPtr("1"),
+				Writers: []*projsvc.UserInfo{
+					{Username: misc.StringPtr("client-credentials|my-service"), Name: misc.StringPtr("My Service")},
+				},
+			},
+			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
+				existingSettings := &models.ProjectSettings{UID: "project-uid-1"}
+				projectDB := &models.ProjectBase{UID: "project-uid-1"}
+				mockRepo.On("ProjectExists", mock.Anything, "project-uid-1").Return(true, nil)
+				mockRepo.On("GetProjectSettings", mock.Anything, "project-uid-1").Return(existingSettings, nil)
+				// Username must be preserved unchanged — no Auth0 lookup should have been attempted.
+				mockRepo.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
+					return len(s.Writers) == 1 && s.Writers[0].Username == "client-credentials|my-service"
+				}), uint64(1)).Return(nil)
+				mockRepo.On("GetProjectBase", mock.Anything, "project-uid-1").Return(projectDB, nil)
+				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("SendAccessMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("SendProjectEventMessage", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
 			name: "metadata enriched from auth service — name and avatar overwritten",
 			payload: &projsvc.UpdateProjectSettingsPayload{
 				UID:     misc.StringPtr("project-uid-1"),


### PR DESCRIPTION
## Summary
- Role fields (`writers`, `auditors`, `meeting_coordinators`) can contain M2M clients that have a username but no email address
- The enrichment step in `enrichAllRoleFields()` was unconditionally clearing `username` to `""` for any entry without an email, silently destroying the M2M client's identity
- Username is now only cleared when both email and username are absent

Fixes LFXV2-2132

🤖 Generated with [Claude Code](https://claude.com/claude-code)