### PR TITLE
[LFXV2-2166] Use LFX username instead of Auth0 sub for FGA tuples

### DIFF
--- a/cmd/project-api/service_endpoint_project_test.go
+++ b/cmd/project-api/service_endpoint_project_test.go
@@ -152,14 +152,14 @@ func TestCreateProject(t *testing.T) {
 				},
 			},
 			setupUserReader: func(mockUserReader *domain.MockUserReader) {
-				mockUserReader.On("SubByEmail", mock.Anything, "user1@example.com").Return("auth0|user1", nil)
-				mockUserReader.On("SubByEmail", mock.Anything, "user2@example.com").Return("auth0|user2", nil)
-				mockUserReader.On("SubByEmail", mock.Anything, "user3@example.com").Return("auth0|user3", nil)
-				mockUserReader.On("SubByEmail", mock.Anything, "user4@example.com").Return("auth0|user4", nil)
-				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "auth0|user1").Return((*domain.UserMetadata)(nil), nil)
-				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "auth0|user2").Return((*domain.UserMetadata)(nil), nil)
-				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "auth0|user3").Return((*domain.UserMetadata)(nil), nil)
-				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "auth0|user4").Return((*domain.UserMetadata)(nil), nil)
+				mockUserReader.On("UsernameByEmail", mock.Anything, "user1@example.com").Return("user1", nil)
+				mockUserReader.On("UsernameByEmail", mock.Anything, "user2@example.com").Return("user2", nil)
+				mockUserReader.On("UsernameByEmail", mock.Anything, "user3@example.com").Return("user3", nil)
+				mockUserReader.On("UsernameByEmail", mock.Anything, "user4@example.com").Return("user4", nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "user1").Return((*domain.UserMetadata)(nil), nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "user2").Return((*domain.UserMetadata)(nil), nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "user3").Return((*domain.UserMetadata)(nil), nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "user4").Return((*domain.UserMetadata)(nil), nil)
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockMsg *domain.MockMessageBuilder) {
 				// Mock parent project exists (for ParentUID validation)
@@ -169,8 +169,8 @@ func TestCreateProject(t *testing.T) {
 				// Mock successful project creation — MatchedBy validates enriched LFIDs were persisted.
 				mockRepo.On("CreateProject", mock.Anything, mock.AnythingOfType("*models.ProjectBase"),
 					mock.MatchedBy(func(s *models.ProjectSettings) bool {
-						return len(s.Writers) == 2 && s.Writers[0].Username == "auth0|user1" && s.Writers[1].Username == "auth0|user2" &&
-							len(s.Auditors) == 2 && s.Auditors[0].Username == "auth0|user3" && s.Auditors[1].Username == "auth0|user4"
+						return len(s.Writers) == 2 && s.Writers[0].Username == "user1" && s.Writers[1].Username == "user2" &&
+							len(s.Auditors) == 2 && s.Auditors[0].Username == "user3" && s.Auditors[1].Username == "user4"
 					})).Return(nil)
 				// Mock message sending
 				mockMsg.On("SendIndexerMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.IndexerMessageEnvelope"), mock.AnythingOfType("bool")).Return(nil).Times(2)

--- a/docs/fga-contract.md
+++ b/docs/fga-contract.md
@@ -48,7 +48,7 @@ Each message carries `object_type`, `operation`, and a `data` map. The sections 
 | `auditor` | Usernames from `ProjectSettings.Auditors` | Only when `Auditors` is non-empty |
 | `meeting_coordinator` | Usernames from `ProjectSettings.MeetingCoordinators` | Only when `MeetingCoordinators` is non-empty |
 
-> Usernames are the `Username` field of each `UserInfo` entry (LFX usernames). If a `UserInfo` entry lacks a pre-resolved username, the service resolves it by email via `lfx.auth-service.email_to_username` before publishing.
+> Usernames are the `Username` field of each `UserInfo` entry (LFX usernames). Before publishing, `enrichAllRoleFields` overwrites `Username` on every entry that includes an email address with the value returned by `lfx.auth-service.email_to_username`; unknown emails clear `Username` to an empty string. Entries with a username but no email are left untouched.
 
 ### References
 

--- a/docs/fga-contract.md
+++ b/docs/fga-contract.md
@@ -48,7 +48,7 @@ Each message carries `object_type`, `operation`, and a `data` map. The sections 
 | `auditor` | Usernames from `ProjectSettings.Auditors` | Only when `Auditors` is non-empty |
 | `meeting_coordinator` | Usernames from `ProjectSettings.MeetingCoordinators` | Only when `MeetingCoordinators` is non-empty |
 
-> Usernames are the `Username` field of each `UserInfo` entry (LFX usernames). When only an email is provided, the service resolves the username via `lfx.auth-service.email_to_username` before publishing.
+> Usernames are the `Username` field of each `UserInfo` entry (LFX usernames). If a `UserInfo` entry lacks a pre-resolved username, the service resolves it by email via `lfx.auth-service.email_to_username` before publishing.
 
 ### References
 

--- a/docs/fga-contract.md
+++ b/docs/fga-contract.md
@@ -48,7 +48,7 @@ Each message carries `object_type`, `operation`, and a `data` map. The sections 
 | `auditor` | Usernames from `ProjectSettings.Auditors` | Only when `Auditors` is non-empty |
 | `meeting_coordinator` | Usernames from `ProjectSettings.MeetingCoordinators` | Only when `MeetingCoordinators` is non-empty |
 
-> Usernames are the `Username` field of each `UserInfo` entry (Auth0 `sub` values).
+> Usernames are the `Username` field of each `UserInfo` entry (LFX usernames). When only an email is provided, the service resolves the username via `lfx.auth-service.email_to_username` before publishing.
 
 ### References
 

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -107,9 +107,9 @@ These fields are indexed and queryable via `filters` or `cel_filter` in the quer
 | `uid` | string | Project UID (same as the parent project) |
 | `mission_statement` | string (optional) | Project mission statement |
 | `announcement_date` | timestamp (optional) | Project announcement date (RFC3339) |
-| `auditors` | []object | Users with audit access. Each object has `avatar` (string), `email` (string), `name` (string), `username` (string — holds the user ID / sub value), and optionally `invite` (object — see [Invite Object](#invite-object)) when the user has no LFID yet |
-| `writers` | []object | Users with write access. Each object has `avatar` (string), `email` (string), `name` (string), `username` (string — holds the user ID / sub value), and optionally `invite` (object — see [Invite Object](#invite-object)) when the user has no LFID yet |
-| `meeting_coordinators` | []object | Users with meeting coordinator access. Each object has `avatar` (string), `email` (string), `name` (string), `username` (string — holds the user ID / sub value), and optionally `invite` (object — see [Invite Object](#invite-object)) when the user has no LFID yet |
+| `auditors` | []object | Users with audit access. Each object has `avatar` (string), `email` (string), `name` (string), `username` (string — LFX username), and optionally `invite` (object — see [Invite Object](#invite-object)) when the user has no LFID yet |
+| `writers` | []object | Users with write access. Each object has `avatar` (string), `email` (string), `name` (string), `username` (string — LFX username), and optionally `invite` (object — see [Invite Object](#invite-object)) when the user has no LFID yet |
+| `meeting_coordinators` | []object | Users with meeting coordinator access. Each object has `avatar` (string), `email` (string), `name` (string), `username` (string — LFX username), and optionally `invite` (object — see [Invite Object](#invite-object)) when the user has no LFID yet |
 | `created_at` | timestamp (optional) | Creation time (RFC3339); null if not yet set |
 | `updated_at` | timestamp (optional) | Last update time (RFC3339); null if not yet set |
 

--- a/internal/domain/mock.go
+++ b/internal/domain/mock.go
@@ -278,7 +278,7 @@ func (m *MockUserReader) UserMetadataByPrincipal(ctx context.Context, principal 
 	return args.Get(0).(*UserMetadata), args.Error(1)
 }
 
-func (m *MockUserReader) SubByEmail(ctx context.Context, email string) (string, error) {
+func (m *MockUserReader) UsernameByEmail(ctx context.Context, email string) (string, error) {
 	args := m.Called(ctx, email)
 	return args.String(0), args.Error(1)
 }

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -27,7 +27,7 @@ type UserMetadata struct {
 type UserReader interface {
 	// UserMetadataByPrincipal retrieves profile metadata for a user by their principal.
 	UserMetadataByPrincipal(ctx context.Context, principal string) (*UserMetadata, error)
-	// SubByEmail resolves the subject identifier for the given primary email address.
+	// UsernameByEmail resolves the registered LFID username for the given primary email address.
 	// Returns ErrUserNotFound when no user is registered with that email.
-	SubByEmail(ctx context.Context, email string) (string, error)
+	UsernameByEmail(ctx context.Context, email string) (string, error)
 }

--- a/internal/infrastructure/nats/user_reader.go
+++ b/internal/infrastructure/nats/user_reader.go
@@ -114,20 +114,20 @@ func (u *UserReaderNATS) UserMetadataByPrincipal(ctx context.Context, principal 
 	return result, nil
 }
 
-// SubByEmail resolves the subject identifier for the given primary email address.
-// The auth service replies with a plain-text subject on success, or a JSON error envelope on miss.
-func (u *UserReaderNATS) SubByEmail(ctx context.Context, email string) (string, error) {
+// UsernameByEmail resolves the registered LFID username for the given primary email address.
+// The auth service replies with a plain-text username on success, or a JSON error envelope on miss.
+func (u *UserReaderNATS) UsernameByEmail(ctx context.Context, email string) (string, error) {
 	reply, err := u.NatsConn.RequestMsgWithContext(ctx, &natsgo.Msg{
-		Subject: constants.AuthEmailToSubSubject,
+		Subject: constants.AuthEmailToUsernameSubject,
 		Data:    []byte(email),
 	})
 	if err != nil {
-		return "", fmt.Errorf("email_to_sub request failed: %w", err)
+		return "", fmt.Errorf("email_to_username request failed: %w", err)
 	}
 
-	// The auth service sends a plain-text subject on success and a JSON error envelope on miss.
+	// The auth service sends a plain-text username on success and a JSON error envelope on miss.
 	// Trim leading/trailing whitespace before inspection so intermediaries that add a trailing
-	// newline or leading space don't corrupt the subject or bypass JSON detection.
+	// newline or leading space don't corrupt the username or bypass JSON detection.
 	body := strings.TrimSpace(string(reply.Data))
 	if body == "" {
 		return "", domain.ErrUserNotFound
@@ -135,7 +135,7 @@ func (u *UserReaderNATS) SubByEmail(ctx context.Context, email string) (string, 
 
 	// Any object-shaped response is an envelope — parse it to distinguish an explicit
 	// not-found from a malformed or unexpected reply. Returning ErrUserNotFound for
-	// non-404 cases would silently clear stored principals in callers that treat
+	// non-404 cases would silently clear stored usernames in callers that treat
 	// ErrUserNotFound as "member disappeared".
 	if body[0] == '{' {
 		var envelope struct {
@@ -143,15 +143,15 @@ func (u *UserReaderNATS) SubByEmail(ctx context.Context, email string) (string, 
 			Error   string `json:"error,omitempty"`
 		}
 		if err := json.Unmarshal(reply.Data, &envelope); err != nil {
-			return "", fmt.Errorf("failed to parse email_to_sub response: %w", err)
+			return "", fmt.Errorf("failed to parse email_to_username response: %w", err)
 		}
 		if envelope.Success == nil {
-			return "", fmt.Errorf("email_to_sub response missing success field")
+			return "", fmt.Errorf("email_to_username response missing success field")
 		}
 		if !*envelope.Success {
 			return "", domain.ErrUserNotFound
 		}
-		return "", fmt.Errorf("unexpected email_to_sub success envelope")
+		return "", fmt.Errorf("unexpected email_to_username success envelope")
 	}
 
 	return body, nil

--- a/internal/infrastructure/nats/user_reader_test.go
+++ b/internal/infrastructure/nats/user_reader_test.go
@@ -23,7 +23,7 @@ import (
 // Transport-error cases should pass nil as the reply directly.
 func replyMsg(data []byte) *natsgo.Msg { return &natsgo.Msg{Data: data} }
 
-func TestUserReaderNATS_SubByEmail(t *testing.T) {
+func TestUserReaderNATS_UsernameByEmail(t *testing.T) {
 	tests := []struct {
 		name       string
 		reply      *natsgo.Msg // nil simulates a transport error
@@ -33,17 +33,12 @@ func TestUserReaderNATS_SubByEmail(t *testing.T) {
 		wantErrStr string
 	}{
 		{
-			name:     "plain-text subject returned on success",
+			name:     "plain-text username returned on success",
 			reply:    replyMsg([]byte("alice")),
 			wantUser: "alice",
 		},
 		{
-			name:     "provider-qualified sub preserved without truncation",
-			reply:    replyMsg([]byte("auth0|alice")),
-			wantUser: "auth0|alice",
-		},
-		{
-			name:     "trailing newline trimmed from subject",
+			name:     "trailing newline trimmed from username",
 			reply:    replyMsg([]byte("alice\n")),
 			wantUser: "alice",
 		},
@@ -70,23 +65,23 @@ func TestUserReaderNATS_SubByEmail(t *testing.T) {
 		{
 			name:       "JSON envelope missing success field returns descriptive error",
 			reply:      replyMsg([]byte(`{"error":"something unexpected"}`)),
-			wantErrStr: "email_to_sub response missing success field",
+			wantErrStr: "email_to_username response missing success field",
 		},
 		{
-			name:       "JSON success envelope returns error instead of leaking JSON as subject",
+			name:       "JSON success envelope returns error instead of leaking JSON as username",
 			reply:      replyMsg([]byte(`{"success":true,"username":"alice"}`)),
-			wantErrStr: "unexpected email_to_sub success envelope",
+			wantErrStr: "unexpected email_to_username success envelope",
 		},
 		{
-			name:       "malformed JSON object returns parse error instead of leaking raw body as subject",
+			name:       "malformed JSON object returns parse error instead of leaking raw body as username",
 			reply:      replyMsg([]byte(`{"success":"true"}`)),
-			wantErrStr: "failed to parse email_to_sub response",
+			wantErrStr: "failed to parse email_to_username response",
 		},
 		{
 			name:       "transport error is wrapped and returned",
 			reply:      nil,
 			replyErr:   errors.New("nats: connection closed"),
-			wantErrStr: "email_to_sub request failed",
+			wantErrStr: "email_to_username request failed",
 		},
 	}
 
@@ -94,11 +89,11 @@ func TestUserReaderNATS_SubByEmail(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockConn := &MockNATSConn{}
 			mockConn.On("RequestMsgWithContext", mock.Anything, mock.MatchedBy(func(msg *natsgo.Msg) bool {
-				return msg.Subject == constants.AuthEmailToSubSubject
+				return msg.Subject == constants.AuthEmailToUsernameSubject
 			})).Return(tt.reply, tt.replyErr)
 
 			reader := &UserReaderNATS{NatsConn: mockConn}
-			got, err := reader.SubByEmail(context.Background(), "test@example.com")
+			got, err := reader.UsernameByEmail(context.Background(), "test@example.com")
 
 			switch {
 			case tt.wantErr != nil:

--- a/internal/service/project_operations.go
+++ b/internal/service/project_operations.go
@@ -824,10 +824,7 @@ func (s *ProjectsService) enrichAllRoleFields(
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			// username holds the auth subject identifier returned by SubByEmail. The field
-			// is named "username" because ProjectSettings stores it under that key —
-			// renaming requires a coordinated data migration with fga-sync.
-			username, err := s.UserReader.SubByEmail(gCtx, email)
+			username, err := s.UserReader.UsernameByEmail(gCtx, email)
 			if err != nil {
 				if errors.Is(err, domain.ErrUserNotFound) {
 					mu.Lock()
@@ -838,7 +835,7 @@ func (s *ProjectsService) enrichAllRoleFields(
 				return err
 			}
 
-			// Subject resolved — now fetch authoritative profile data.
+			// Username resolved — now fetch authoritative profile data.
 			// Metadata failures are non-fatal: display fields must not block the write.
 			var meta *domain.UserMetadata
 			if username != "" {

--- a/internal/service/project_operations_test.go
+++ b/internal/service/project_operations_test.go
@@ -231,13 +231,13 @@ func TestProjectsService_CreateProject(t *testing.T) {
 				},
 			},
 			setupUserReader: func(mockUserReader *domain.MockUserReader) {
-				mockUserReader.On("SubByEmail", mock.Anything, "carol@example.com").Return("auth0|carol-lfid", nil)
-				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "auth0|carol-lfid").Return((*domain.UserMetadata)(nil), nil)
+				mockUserReader.On("UsernameByEmail", mock.Anything, "carol@example.com").Return("carol-lfid", nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "carol-lfid").Return((*domain.UserMetadata)(nil), nil)
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
 				mockRepo.On("ProjectSlugExists", mock.Anything, "new-project").Return(false, nil)
 				mockRepo.On("CreateProject", mock.Anything, mock.AnythingOfType("*models.ProjectBase"), mock.MatchedBy(func(s *models.ProjectSettings) bool {
-					return len(s.Writers) == 1 && s.Writers[0].Username == "auth0|carol-lfid"
+					return len(s.Writers) == 1 && s.Writers[0].Username == "carol-lfid"
 				})).Return(nil)
 				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(2)
 				mockBuilder.On("SendAccessMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -894,14 +894,14 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				},
 			},
 			setupUserReader: func(mockUserReader *domain.MockUserReader) {
-				mockUserReader.On("SubByEmail", mock.Anything, "alice@example.com").Return("auth0|alice", nil)
-				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "auth0|alice").Return((*domain.UserMetadata)(nil), nil)
+				mockUserReader.On("UsernameByEmail", mock.Anything, "alice@example.com").Return("alice", nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "alice").Return((*domain.UserMetadata)(nil), nil)
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
 				existingSettings := &models.ProjectSettings{UID: "project-uid-1", CreatedAt: func() *time.Time { t := time.Now(); return &t }()}
 				updatedSettings := &models.ProjectSettings{
 					UID:     "project-uid-1",
-					Writers: []models.UserInfo{{Username: "auth0|alice", Name: "Alice", Email: "alice@example.com"}},
+					Writers: []models.UserInfo{{Username: "alice", Name: "Alice", Email: "alice@example.com"}},
 				}
 				projectDB := &models.ProjectBase{UID: "project-uid-1", Public: true}
 
@@ -940,8 +940,8 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				},
 			},
 			setupUserReader: func(mockUserReader *domain.MockUserReader) {
-				mockUserReader.On("SubByEmail", mock.Anything, "bob@example.com").Return("auth0|real-bob", nil)
-				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "auth0|real-bob").Return((*domain.UserMetadata)(nil), nil)
+				mockUserReader.On("UsernameByEmail", mock.Anything, "bob@example.com").Return("real-bob", nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "real-bob").Return((*domain.UserMetadata)(nil), nil)
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
 				existingSettings := &models.ProjectSettings{UID: "project-uid-1"}
@@ -949,7 +949,7 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				mockRepo.On("ProjectExists", mock.Anything, "project-uid-1").Return(true, nil)
 				mockRepo.On("GetProjectSettings", mock.Anything, "project-uid-1").Return(existingSettings, nil)
 				mockRepo.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
-					return len(s.Writers) == 1 && s.Writers[0].Username == "auth0|real-bob"
+					return len(s.Writers) == 1 && s.Writers[0].Username == "real-bob"
 				}), uint64(1)).Return(nil)
 				mockRepo.On("GetProjectBase", mock.Anything, "project-uid-1").Return(projectDB, nil)
 				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -968,7 +968,7 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				},
 			},
 			setupUserReader: func(mockUserReader *domain.MockUserReader) {
-				mockUserReader.On("SubByEmail", mock.Anything, "nobody@example.com").Return("", domain.ErrUserNotFound)
+				mockUserReader.On("UsernameByEmail", mock.Anything, "nobody@example.com").Return("", domain.ErrUserNotFound)
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
 				existingSettings := &models.ProjectSettings{UID: "project-uid-1"}
@@ -1019,7 +1019,7 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				},
 			},
 			setupUserReader: func(mockUserReader *domain.MockUserReader) {
-				mockUserReader.On("SubByEmail", mock.Anything, "eve@example.com").Return("", assert.AnError)
+				mockUserReader.On("UsernameByEmail", mock.Anything, "eve@example.com").Return("", assert.AnError)
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
 				existingSettings := &models.ProjectSettings{UID: "project-uid-1"}
@@ -1041,7 +1041,7 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				},
 			},
 			setupUserReader: func(mockUserReader *domain.MockUserReader) {
-				mockUserReader.On("SubByEmail", mock.Anything, "gone@example.com").Return("", domain.ErrUserNotFound)
+				mockUserReader.On("UsernameByEmail", mock.Anything, "gone@example.com").Return("", domain.ErrUserNotFound)
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
 				// Existing settings already have a writer with the same email and a stored LFID.
@@ -1102,8 +1102,8 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				},
 			},
 			setupUserReader: func(mockUserReader *domain.MockUserReader) {
-				mockUserReader.On("SubByEmail", mock.Anything, "carol@example.com").Return("auth0|carol-lfid", nil)
-				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "auth0|carol-lfid").Return(&domain.UserMetadata{
+				mockUserReader.On("UsernameByEmail", mock.Anything, "carol@example.com").Return("carol-lfid", nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "carol-lfid").Return(&domain.UserMetadata{
 					Name:    "Carol Real Name",
 					Picture: "https://auth.example.com/carol.png",
 				}, nil)
@@ -1116,7 +1116,7 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				// Username, name, and avatar must all come from auth service, not the caller.
 				mockRepo.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
 					return len(s.Writers) == 1 &&
-						s.Writers[0].Username == "auth0|carol-lfid" &&
+						s.Writers[0].Username == "carol-lfid" &&
 						s.Writers[0].Name == "Carol Real Name" &&
 						s.Writers[0].Avatar == "https://auth.example.com/carol.png"
 				}), uint64(1)).Return(nil)
@@ -1137,8 +1137,8 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				},
 			},
 			setupUserReader: func(mockUserReader *domain.MockUserReader) {
-				mockUserReader.On("SubByEmail", mock.Anything, "dave@example.com").Return("auth0|dave-lfid", nil)
-				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "auth0|dave-lfid").Return((*domain.UserMetadata)(nil), assert.AnError)
+				mockUserReader.On("UsernameByEmail", mock.Anything, "dave@example.com").Return("dave-lfid", nil)
+				mockUserReader.On("UserMetadataByPrincipal", mock.Anything, "dave-lfid").Return((*domain.UserMetadata)(nil), assert.AnError)
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
 				existingSettings := &models.ProjectSettings{UID: "project-uid-1"}
@@ -1148,7 +1148,7 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				// Username is enriched; name/avatar keep caller-supplied values when metadata fails.
 				mockRepo.On("UpdateProjectSettings", mock.Anything, mock.MatchedBy(func(s *models.ProjectSettings) bool {
 					return len(s.Writers) == 1 &&
-						s.Writers[0].Username == "auth0|dave-lfid" &&
+						s.Writers[0].Username == "dave-lfid" &&
 						s.Writers[0].Name == "Dave" && // caller-supplied — not overwritten on metadata failure
 						s.Writers[0].Avatar == "" // caller supplied no avatar — still empty
 				}), uint64(1)).Return(nil)

--- a/pkg/constants/nats.go
+++ b/pkg/constants/nats.go
@@ -101,7 +101,7 @@ const (
 	// The subject is of the form: lfx.auth-service.user_metadata.read
 	AuthUserMetadataReadSubject = "lfx.auth-service.user_metadata.read"
 
-	// AuthEmailToSubSubject resolves a subject identifier (e.g. auth0|jmedev) by primary email.
-	// Request: plain-text email. Reply: plain-text subject on success, JSON error envelope on miss.
-	AuthEmailToSubSubject = "lfx.auth-service.email_to_sub"
+	// AuthEmailToUsernameSubject resolves a registered LFID username by primary email.
+	// Request: plain-text email. Reply: plain-text username on success, JSON error envelope on miss.
+	AuthEmailToUsernameSubject = "lfx.auth-service.email_to_username"
 )


### PR DESCRIPTION
## Summary

- Switch `UserReader` from `SubByEmail` / `email_to_sub` to `UsernameByEmail` / `email_to_username` so writers, auditors, and meeting coordinators resolve to LFX usernames.
- Update FGA and indexer contract docs to describe `username` fields as LFX usernames, not Auth0 subs.
- Adjust unit and endpoint tests to expect plain usernames (e.g. `carol-lfid`) instead of `auth0|...` values.

Data migration of existing stored tuples is intentionally out of scope for this PR — tracked separately in [LFXV2-1963](https://linuxfoundation.atlassian.net/browse/LFXV2-1963).

[LFXV2-1963]: https://linuxfoundation.atlassian.net/browse/LFXV2-1963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ