### PR TITLE
feat: add topologySpreadConstraints to Helm chart

### DIFF
--- a/charts/lfx-v2-project-service/templates/deployment.yaml
+++ b/charts/lfx-v2-project-service/templates/deployment.yaml
@@ -143,3 +143,7 @@ spec:
               value: {{ .Values.rootProject.writers | join "," | quote }}
             - name: ROOT_PROJECT_AUDITORS
               value: {{ .Values.rootProject.auditors | join "," | quote }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/lfx-v2-project-service/values.yaml
+++ b/charts/lfx-v2-project-service/values.yaml
@@ -41,6 +41,16 @@ podDisruptionBudget:
   # minAvailable: 1
   # maxUnavailable: 1
 
+# topologySpreadConstraints controls how pods are spread across nodes/zones.
+# Empty by default (no constraints). Example:
+#   - maxSkew: 1
+#     topologyKey: kubernetes.io/hostname
+#     whenUnsatisfiable: DoNotSchedule
+#     labelSelector:
+#       matchLabels:
+#         app: lfx-v2-project-service
+topologySpreadConstraints: []
+
 # resources is the configuration for container resource limits and requests
 resources:
   # limits is the maximum amount of resources the container can use


### PR DESCRIPTION
## Summary

- Add `topologySpreadConstraints: []` to `values.yaml` (empty default, no-op unless overridden)
- Add conditional `{{- with .Values.topologySpreadConstraints }}` block to `deployment.yaml` at the pod spec level

## Test plan

- [x] `helm lint` passes with no errors
- [x] `helm template` with empty default produces no `topologySpreadConstraints` block
- [x] `helm template` with constraints set renders correctly at pod spec level

## Context

Part of LFXV2-1167: add topology spread constraints to all LFX v2 services so pods spread across nodes and availability zones, preventing a single node drain from taking out all replicas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)