### PR TITLE
feat(nats): add NATS span instrumentation to project-service

### DIFF
--- a/internal/infrastructure/nats/tracing.go
+++ b/internal/infrastructure/nats/tracing.go
@@ -20,6 +20,9 @@ var tracer = otel.Tracer("github.com/linuxfoundation/lfx-v2-project-service/inte
 
 // natsHeaderCarrier adapts nats.Header to the OTel TextMapCarrier interface
 // so trace context can be injected/extracted from NATS message headers.
+// Callers must provide an initialized (non-nil) header map before injection;
+// Set is a no-op on a nil map to safely support extraction from messages
+// that arrive without headers.
 type natsHeaderCarrier natsgo.Header
 
 func (c natsHeaderCarrier) Get(key string) string {

--- a/internal/infrastructure/nats/tracing.go
+++ b/internal/infrastructure/nats/tracing.go
@@ -6,7 +6,7 @@ package nats
 import (
 	"context"
 
-	"github.com/nats-io/nats.go"
+	natsgo "github.com/nats-io/nats.go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
@@ -19,8 +19,8 @@ import (
 var tracer = otel.Tracer("github.com/linuxfoundation/lfx-v2-project-service/internal/infrastructure/nats")
 
 // natsHeaderCarrier adapts nats.Header to the OTel TextMapCarrier interface
-// so trace context can be injected into NATS message headers.
-type natsHeaderCarrier nats.Header
+// so trace context can be injected/extracted from NATS message headers.
+type natsHeaderCarrier natsgo.Header
 
 func (c natsHeaderCarrier) Get(key string) string {
 	vals := c[key]
@@ -31,6 +31,9 @@ func (c natsHeaderCarrier) Get(key string) string {
 }
 
 func (c natsHeaderCarrier) Set(key string, value string) {
+	if c == nil {
+		return
+	}
 	c[key] = []string{value}
 }
 
@@ -44,25 +47,24 @@ func (c natsHeaderCarrier) Keys() []string {
 
 var _ propagation.TextMapCarrier = natsHeaderCarrier{}
 
-// ExtractMsgContext extracts OTel trace context from an incoming NATS message
-// header and starts a Consumer span. Call the returned function (typically via
-// defer) to end the span.
-func ExtractMsgContext(ctx context.Context, msg *nats.Msg, subject string) (context.Context, func()) {
-	var hdr nats.Header
-	if msg.Header != nil {
-		hdr = msg.Header
-	}
-	msgCtx := otel.GetTextMapPropagator().Extract(ctx, natsHeaderCarrier(hdr))
+// ExtractTraceContext extracts the OTel trace context from NATS message headers.
+func ExtractTraceContext(ctx context.Context, header natsgo.Header) context.Context {
+	return otel.GetTextMapPropagator().Extract(ctx, natsHeaderCarrier(header))
+}
+
+// ExtractMsgContext extracts trace context from NATS message headers and starts a consumer span.
+// It returns a new context with the extracted trace and a function to end the span.
+// The returned function must be called with defer to ensure the span is properly closed.
+func ExtractMsgContext(ctx context.Context, msg *natsgo.Msg, subject string) (context.Context, func()) {
+	msgCtx := ExtractTraceContext(ctx, msg.Header)
 	msgCtx, span := tracer.Start(msgCtx, "nats.process",
 		trace.WithSpanKind(trace.SpanKindConsumer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "nats"),
-			attribute.String("messaging.operation.type", "process"),
 			attribute.String("messaging.destination.name", subject),
+			attribute.String("messaging.operation.type", "process"),
 			attribute.Int("messaging.message.body.size", len(msg.Data)),
 		),
 	)
-	return msgCtx, func() {
-		span.End()
-	}
+	return msgCtx, func() { span.End() }
 }

--- a/internal/infrastructure/nats/tracing_test.go
+++ b/internal/infrastructure/nats/tracing_test.go
@@ -40,6 +40,12 @@ func TestNatsHeaderCarrier_Get(t *testing.T) {
 }
 
 func TestNatsHeaderCarrier_Set(t *testing.T) {
+	t.Run("is a no-op for nil carrier", func(t *testing.T) {
+		var carrier natsHeaderCarrier
+		carrier.Set("key", "value") // must not panic
+		assert.Equal(t, "", carrier.Get("key"))
+	})
+
 	t.Run("sets value on new key", func(t *testing.T) {
 		carrier := natsHeaderCarrier(make(natsgo.Header))
 		carrier.Set("traceparent", "00-abc-def-01")


### PR DESCRIPTION
Adds OTel producer spans to all NATS publish operations, client spans to request/reply calls (invite-service, email-service, auth-service user metadata), and consumer spans to incoming queue subscriptions; references LFXV2-1743