### PR TITLE
fix: default self-serve base URL to prod when LFX_ENVIRONMENT is unset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,8 +335,8 @@ func TestEndpoint(t *testing.T) {
 | `AUDIENCE` | JWT audience | lfx-v2-project-service | No |
 | `JWT_AUTH_DISABLED_MOCK_LOCAL_PRINCIPAL` | Mock auth for local dev | - | No |
 | `SKIP_ETAG_VALIDATION` | Skip If-Match/ETag revision enforcement on writes (`true` to skip; local dev only) | false | No |
-| `LFX_ENVIRONMENT` | Deployment environment (`prod`, `staging`/`stg`, else dev); drives the default self-serve base URL | - | No |
-| `LFX_SELF_SERVE_BASE_URL` | Base URL for project links in notification emails | derived from `LFX_ENVIRONMENT` | No |
+| `LFX_ENVIRONMENT` | Deployment environment (`prod`/`production`, `staging`/`stg`/`stage`, `dev`/`development`); drives the default self-serve base URL when `LFX_SELF_SERVE_BASE_URL` is empty; defaults to prod when unset | - | No |
+| `LFX_SELF_SERVE_BASE_URL` | Base URL for project links in notification emails; takes precedence over `LFX_ENVIRONMENT` | derived from `LFX_ENVIRONMENT` (prod when unset) | No |
 | `EMAILS_ENABLED` | Gate for outbound role-notification emails to LFID users (`true` to enable) | false | No |
 | `INVITES_ENABLED` | Gate for outbound invite requests to non-LFID users (`true` to enable) | false | No |
 

--- a/charts/lfx-v2-project-service/templates/deployment.yaml
+++ b/charts/lfx-v2-project-service/templates/deployment.yaml
@@ -49,6 +49,8 @@ spec:
               value: {{ .Values.app.emailsEnabled | quote }}
             - name: INVITES_ENABLED
               value: {{ .Values.app.invitesEnabled | quote }}
+            - name: LFX_SELF_SERVE_BASE_URL
+              value: {{ .Values.app.lfxSelfServeBaseURL | quote }}
             - name: JWT_AUTH_DISABLED_MOCK_LOCAL_PRINCIPAL
               value: {{ .Values.app.jwtAuthDisabledMockLocalPrincipal }}
             {{- with .Values.app.extraEnv }}

--- a/charts/lfx-v2-project-service/templates/deployment.yaml
+++ b/charts/lfx-v2-project-service/templates/deployment.yaml
@@ -49,6 +49,8 @@ spec:
               value: {{ .Values.app.emailsEnabled | quote }}
             - name: INVITES_ENABLED
               value: {{ .Values.app.invitesEnabled | quote }}
+            - name: LFX_ENVIRONMENT
+              value: {{ .Values.app.lfxEnvironment | quote }}
             - name: LFX_SELF_SERVE_BASE_URL
               value: {{ .Values.app.lfxSelfServeBaseURL | quote }}
             - name: JWT_AUTH_DISABLED_MOCK_LOCAL_PRINCIPAL

--- a/charts/lfx-v2-project-service/values.yaml
+++ b/charts/lfx-v2-project-service/values.yaml
@@ -79,6 +79,9 @@ app:
   # invitesEnabled gates outbound invite requests for non-LFID users via the invite service.
   # Disabled by default; set to true in environments where invite sending should be active.
   invitesEnabled: false
+  # lfxEnvironment is the deployment environment (dev, staging, prod).
+  # Drives LFXSelfServeBaseURL() when LFX_SELF_SERVE_BASE_URL is empty.
+  lfxEnvironment: ""
   # lfxSelfServeBaseURL is the base URL for project links in notification emails.
   # When empty, the service derives the URL from LFX_ENVIRONMENT (defaulting to prod).
   lfxSelfServeBaseURL: ""

--- a/charts/lfx-v2-project-service/values.yaml
+++ b/charts/lfx-v2-project-service/values.yaml
@@ -79,6 +79,9 @@ app:
   # invitesEnabled gates outbound invite requests for non-LFID users via the invite service.
   # Disabled by default; set to true in environments where invite sending should be active.
   invitesEnabled: false
+  # lfxSelfServeBaseURL is the base URL for project links in notification emails.
+  # When empty, the service derives the URL from LFX_ENVIRONMENT (defaulting to prod).
+  lfxSelfServeBaseURL: ""
   # jwtAuthDisabledMockLocalPrincipal mocks auth for local development to use a set principal
   # (only use for local development)
   jwtAuthDisabledMockLocalPrincipal: ""

--- a/cmd/project-api/main.go
+++ b/cmd/project-api/main.go
@@ -199,7 +199,7 @@ func parseEnv() environment {
 
 // LFXSelfServeBaseURL derives the LFX Self-Serve base URL from environment variables.
 // LFX_SELF_SERVE_BASE_URL takes precedence; otherwise it falls back to LFX_ENVIRONMENT.
-// When LFX_ENVIRONMENT is unset, prod is assumed (safe default for deployed environments).
+// When LFX_ENVIRONMENT is unset or unrecognized, prod is assumed (safe default for deployed environments).
 func LFXSelfServeBaseURL() string {
 	if url := os.Getenv("LFX_SELF_SERVE_BASE_URL"); url != "" {
 		return url

--- a/cmd/project-api/main.go
+++ b/cmd/project-api/main.go
@@ -186,17 +186,7 @@ func parseEnv() environment {
 	if skipEtagValidationStr == "true" {
 		skipEtagValidation = true
 	}
-	lfxSelfServeBaseURL := os.Getenv("LFX_SELF_SERVE_BASE_URL")
-	if lfxSelfServeBaseURL == "" {
-		switch os.Getenv("LFX_ENVIRONMENT") {
-		case "prod":
-			lfxSelfServeBaseURL = "https://app.lfx.dev"
-		case "staging", "stg":
-			lfxSelfServeBaseURL = "https://app.staging.lfx.dev"
-		default:
-			lfxSelfServeBaseURL = "https://app.dev.lfx.dev"
-		}
-	}
+	lfxSelfServeBaseURL := LFXSelfServeBaseURL()
 	return environment{
 		NatsURL:             natsURL,
 		Port:                port,
@@ -204,6 +194,25 @@ func parseEnv() environment {
 		LFXSelfServeBaseURL: lfxSelfServeBaseURL,
 		EmailsEnabled:       os.Getenv("EMAILS_ENABLED") == "true",
 		InvitesEnabled:      os.Getenv("INVITES_ENABLED") == "true",
+	}
+}
+
+// LFXSelfServeBaseURL derives the LFX Self-Serve base URL from environment variables.
+// LFX_SELF_SERVE_BASE_URL takes precedence; otherwise it falls back to LFX_ENVIRONMENT.
+// When LFX_ENVIRONMENT is unset, prod is assumed (safe default for deployed environments).
+func LFXSelfServeBaseURL() string {
+	if url := os.Getenv("LFX_SELF_SERVE_BASE_URL"); url != "" {
+		return url
+	}
+	switch os.Getenv("LFX_ENVIRONMENT") {
+	case "prod", "production":
+		return "https://app.lfx.dev"
+	case "staging", "stg", "stage":
+		return "https://app.staging.lfx.dev"
+	case "dev", "development":
+		return "https://app.dev.lfx.dev"
+	default:
+		return "https://app.lfx.dev"
 	}
 }
 

--- a/cmd/project-api/main_test.go
+++ b/cmd/project-api/main_test.go
@@ -1,0 +1,73 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLFXSelfServeBaseURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		baseURL     string
+		environment string
+		want        string
+	}{
+		{
+			name:    "explicit base URL takes precedence",
+			baseURL: "https://custom.example.com",
+			want:    "https://custom.example.com",
+		},
+		{
+			name:        "prod environment",
+			environment: "prod",
+			want:        "https://app.lfx.dev",
+		},
+		{
+			name:        "production alias",
+			environment: "production",
+			want:        "https://app.lfx.dev",
+		},
+		{
+			name:        "staging environment",
+			environment: "staging",
+			want:        "https://app.staging.lfx.dev",
+		},
+		{
+			name:        "stg alias",
+			environment: "stg",
+			want:        "https://app.staging.lfx.dev",
+		},
+		{
+			name:        "stage alias",
+			environment: "stage",
+			want:        "https://app.staging.lfx.dev",
+		},
+		{
+			name:        "dev environment",
+			environment: "dev",
+			want:        "https://app.dev.lfx.dev",
+		},
+		{
+			name:        "development alias",
+			environment: "development",
+			want:        "https://app.dev.lfx.dev",
+		},
+		{
+			name: "unset environment defaults to prod",
+			want: "https://app.lfx.dev",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("LFX_SELF_SERVE_BASE_URL", tt.baseURL)
+			t.Setenv("LFX_ENVIRONMENT", tt.environment)
+
+			assert.Equal(t, tt.want, LFXSelfServeBaseURL())
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Extract `LFXSelfServeBaseURL()` so notification email links resolve from `LFX_SELF_SERVE_BASE_URL` or `LFX_ENVIRONMENT`, defaulting to **prod** (`https://app.lfx.dev`) when neither is set — fixing prod emails that incorrectly used the dev URL
- Wire `app.lfxSelfServeBaseURL` through the Helm chart as `LFX_SELF_SERVE_BASE_URL`, enabling per-environment values from argo
- Add unit tests covering explicit override, all environment aliases, and the prod-safe default

Companion to [lfx-v2-argocd#1071](https://github.com/linuxfoundation/lfx-v2-argocd/pull/1071), which sets `app.lfxSelfServeBaseURL` in dev/staging/prod argo values.

## Ticket

[LFXV2-1775](https://jira.linuxfoundation.org/browse/LFXV2-1775)

## Test plan

- [x] `go test ./cmd/project-api/... -run TestLFXSelfServeBaseURL`
- [ ] After both PRs merge and deploy, verify project role notification emails in prod contain `https://app.lfx.dev/project/overview/...` links


Made with [Cursor](https://cursor.com)

[LFXV2-1775]: https://linuxfoundation.atlassian.net/browse/LFXV2-1775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ