### PR TITLE
fix: deny /projects list endpoint in deployed environments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,7 +344,7 @@ func TestEndpoint(t *testing.T) {
 
 When deployed, the service uses OpenFGA for authorization:
 
-- **GET /projects** - No check (public list)
+- **GET /projects** - Denied in deployed environments (local development only)
 - **POST /projects** - Requires `writer` on parent (if specified)
 - **GET /projects/:id** - Requires `viewer` on project
 - **GET /projects/:id/settings** - Requires `auditor` on project

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -443,7 +443,7 @@ openfga:
 
 When OpenFGA is enabled, the following authorization checks are enforced:
 
-- **GET /projects** - No OpenFGA check (returns list of all projects)
+- **GET /projects** - Denied in deployed environments (local development only)
 - **POST /projects** - Requires `writer` relation on the parent project (if parent_uid is specified)
 - **GET /projects/:id** - Requires `viewer` relation on the specific project
 - **GET /projects/:id/settings** - Requires `auditor` relation on the specific project

--- a/charts/lfx-v2-project-service/templates/ruleset.yaml
+++ b/charts/lfx-v2-project-service/templates/ruleset.yaml
@@ -61,9 +61,6 @@ spec:
             values:
               aud: {{ .Values.app.audience }}
 
-    # TODO: remove this rule once we remove the list projects endpoint.
-    # It is not meant to be used by applications, it should only be used
-    # in local development, therefore the authorizer allows all requests.
     - id: "rule:lfx:lfx-v2-project-service:projects:list"
       allow_encoded_slashes: "off"
       match:
@@ -77,7 +74,11 @@ spec:
         {{- if .Values.app.use_oidc_contextualizer }}
         - contextualizer: oidc_contextualizer
         {{- end }}
+        {{- if .Values.openfga.enabled }}
+        - authorizer: deny_all
+        {{- else }}
         - authorizer: allow_all
+        {{- end }}
         - finalizer: create_jwt
           config:
             values:


### PR DESCRIPTION
## Summary

- Changes the Heimdall ruleset authorizer for `GET /projects` from `allow_all` to `deny_all`, blocking this dev-only endpoint in all deployed environments
- Removes the stale TODO comment that documented the previous (incorrect) behavior
- Updates CLAUDE.md and DEVELOPMENT.md to reflect that the endpoint is denied in production

Fixes LFXV2-2523 (June 2026 Bugs epic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)