### PR TITLE
refactor: make project FGA update_access and delete_access publishing asynchronous-only

### DIFF
--- a/cmd/project-api/service_endpoint_project_test.go
+++ b/cmd/project-api/service_endpoint_project_test.go
@@ -174,7 +174,7 @@ func TestCreateProject(t *testing.T) {
 					})).Return(nil)
 				// Mock message sending
 				mockMsg.On("SendIndexerMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.IndexerMessageEnvelope"), mock.AnythingOfType("bool")).Return(nil).Times(2)
-				mockMsg.On("SendAccessMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.GenericFGAMessage"), mock.AnythingOfType("bool")).Return(nil)
+				mockMsg.On("PublishAccessMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.GenericFGAMessage")).Return(nil)
 			},
 			expectedError: false,
 		},

--- a/docs/fga-contract.md
+++ b/docs/fga-contract.md
@@ -25,6 +25,12 @@ All messages use the generic FGA message format on the following NATS subjects:
 
 Each message carries `object_type`, `operation`, and a `data` map. The sections below describe the `data` contents for each object type.
 
+### Delivery Semantics
+
+Project create, base update, and settings update publish `lfx.fga-sync.update_access` asynchronously. For those operations, `X-Sync` controls indexer synchronization only; it does not wait for FGA processing or OpenFGA convergence.
+
+Project deletion also publishes `lfx.fga-sync.delete_access` asynchronously. `X-Sync` continues to control both project indexer deletion messages, but it does not wait for FGA deletion processing or OpenFGA convergence.
+
 ---
 
 ## Project

--- a/internal/domain/message.go
+++ b/internal/domain/message.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	emailapi "github.com/linuxfoundation/lfx-v2-email-service/pkg/api"
+	fgatypes "github.com/linuxfoundation/lfx-v2-fga-sync/pkg/types"
 	inviteapi "github.com/linuxfoundation/lfx-v2-invite-service/pkg/api"
 )
 
@@ -33,7 +34,7 @@ type InviteResult struct {
 // MessageBuilder is a generic interface for sending messages to NATS.
 type MessageBuilder interface {
 	SendIndexerMessage(ctx context.Context, subject string, message any, sync bool) error
-	SendAccessMessage(ctx context.Context, subject string, message any, sync bool) error
+	PublishAccessMessage(ctx context.Context, subject string, message fgatypes.GenericFGAMessage) error
 	SendProjectEventMessage(ctx context.Context, subject string, message any) error
 	SendEmailRequest(ctx context.Context, req emailapi.SendEmailRequest) error
 	SendInviteRequest(ctx context.Context, req inviteapi.SendInviteRequest) (InviteResult, error)

--- a/internal/domain/mock.go
+++ b/internal/domain/mock.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	emailapi "github.com/linuxfoundation/lfx-v2-email-service/pkg/api"
+	fgatypes "github.com/linuxfoundation/lfx-v2-fga-sync/pkg/types"
 	inviteapi "github.com/linuxfoundation/lfx-v2-invite-service/pkg/api"
 	"github.com/linuxfoundation/lfx-v2-project-service/internal/domain/models"
 )
@@ -242,8 +243,8 @@ func (m *MockMessageBuilder) SendIndexerMessage(ctx context.Context, subject str
 	return args.Error(0)
 }
 
-func (m *MockMessageBuilder) SendAccessMessage(ctx context.Context, subject string, message any, sync bool) error {
-	args := m.Called(ctx, subject, message, sync)
+func (m *MockMessageBuilder) PublishAccessMessage(ctx context.Context, subject string, message fgatypes.GenericFGAMessage) error {
+	args := m.Called(ctx, subject, message)
 	return args.Error(0)
 }
 

--- a/internal/infrastructure/nats/message.go
+++ b/internal/infrastructure/nats/message.go
@@ -218,21 +218,14 @@ func (m *MessageBuilder) SendIndexerMessage(ctx context.Context, subject string,
 	}
 }
 
-// SendAccessMessage sends access control messages to NATS using the generic FGA sync format.
-func (m *MessageBuilder) SendAccessMessage(ctx context.Context, subject string, message interface{}, sync bool) error {
-	switch msg := message.(type) {
-	case fgatypes.GenericFGAMessage:
-		messageBytes, err := json.Marshal(msg)
-		if err != nil {
-			slog.ErrorContext(ctx, "error marshalling FGA message into JSON", constants.ErrKey, err)
-			return err
-		}
-		return m.sendMessage(ctx, subject, messageBytes, sync)
-
-	default:
-		slog.ErrorContext(ctx, "unsupported access message type", "type", fmt.Sprintf("%T", message))
-		return fmt.Errorf("unsupported access message type: %T", message)
+// PublishAccessMessage publishes access control messages asynchronously using the generic FGA sync format.
+func (m *MessageBuilder) PublishAccessMessage(ctx context.Context, subject string, message fgatypes.GenericFGAMessage) error {
+	messageBytes, err := json.Marshal(message)
+	if err != nil {
+		slog.ErrorContext(ctx, "error marshalling FGA message into JSON", constants.ErrKey, err)
+		return err
 	}
+	return m.sendMessage(ctx, subject, messageBytes, false)
 }
 
 // SendProjectEventMessage sends project event messages to NATS asynchronously.

--- a/internal/infrastructure/nats/message_test.go
+++ b/internal/infrastructure/nats/message_test.go
@@ -4,9 +4,12 @@
 package nats
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
+	"sync"
 	"testing"
 	"time"
 
@@ -23,6 +26,12 @@ import (
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 // backgroundCtx is a reusable function that returns context.Background()
@@ -253,14 +262,65 @@ func TestMessageBuilder_PublishIndexerMessage_Sync(t *testing.T) {
 	}
 }
 
+// matchFGAEnvelope builds a mock.MatchedBy predicate asserting that a published
+// NATS message carries the given subject and decodes to the expected FGA
+// envelope fields (object_type, operation, and the data's uid).
+func matchFGAEnvelope(subject, operation, uid string) func(msg *nats.Msg) bool {
+	return func(msg *nats.Msg) bool {
+		if msg.Subject != subject {
+			return false
+		}
+		var envelope struct {
+			ObjectType string `json:"object_type"`
+			Operation  string `json:"operation"`
+			Data       struct {
+				UID string `json:"uid"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(msg.Data, &envelope); err != nil {
+			return false
+		}
+		return envelope.ObjectType == "project" &&
+			envelope.Operation == operation &&
+			envelope.Data.UID == uid
+	}
+}
+
+// accessMessageSpanRecorder/accessMessageTracerProvider back the trace
+// assertions in TestMessageBuilder_PublishAccessMessage. otel.SetTracerProvider
+// only performs a one-time delegate upgrade for already-resolved package-level
+// Tracer handles (see tracing.go), so it must be installed at most once for
+// the lifetime of the test binary — including across repeated runs of the
+// same test function under `go test -count=N`. Trace assertions therefore
+// compare span-count deltas against this shared recorder instead of resetting it.
+var (
+	accessMessageTracerOnce     sync.Once
+	accessMessageSpanRecorder   *tracetest.SpanRecorder
+	accessMessageTracerProvider *sdktrace.TracerProvider
+)
+
+func setupAccessMessageTracing() *tracetest.SpanRecorder {
+	accessMessageTracerOnce.Do(func() {
+		accessMessageSpanRecorder = tracetest.NewSpanRecorder()
+		accessMessageTracerProvider = sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(accessMessageSpanRecorder))
+		otel.SetTracerProvider(accessMessageTracerProvider)
+		otel.SetTextMapPropagator(propagation.TraceContext{})
+	})
+	return accessMessageSpanRecorder
+}
+
 func TestMessageBuilder_PublishAccessMessage(t *testing.T) {
+	spanRecorder := setupAccessMessageTracing()
+
 	tests := []struct {
-		name       string
-		subject    string
-		message    interface{}
-		setupMocks func(*MockNATSConn)
-		setupCtx   func() context.Context
-		wantErr    bool
+		name             string
+		subject          string
+		message          fgatypes.GenericFGAMessage
+		setupMocks       func(*MockNATSConn)
+		setupCtx         func() context.Context
+		wantErr          bool
+		verifyTrace      bool
+		verifyFailureLog bool
 	}{
 		{
 			name:    "successful send update access message",
@@ -281,12 +341,13 @@ func TestMessageBuilder_PublishAccessMessage(t *testing.T) {
 				},
 			},
 			setupMocks: func(mockConn *MockNATSConn) {
-				mockConn.On("PublishMsg", mock.MatchedBy(func(msg *nats.Msg) bool {
-					return msg.Subject == fgaconstants.GenericUpdateAccessSubject
-				})).Return(nil)
+				mockConn.On("PublishMsg", mock.MatchedBy(
+					matchFGAEnvelope(fgaconstants.GenericUpdateAccessSubject, "update_access", "test-uid"),
+				)).Return(nil)
 			},
-			setupCtx: backgroundCtx,
-			wantErr:  false,
+			setupCtx:    backgroundCtx,
+			wantErr:     false,
+			verifyTrace: true,
 		},
 		{
 			name:    "successful send delete access message",
@@ -299,22 +360,13 @@ func TestMessageBuilder_PublishAccessMessage(t *testing.T) {
 				},
 			},
 			setupMocks: func(mockConn *MockNATSConn) {
-				mockConn.On("PublishMsg", mock.MatchedBy(func(msg *nats.Msg) bool {
-					return msg.Subject == fgaconstants.GenericDeleteAccessSubject
-				})).Return(nil)
+				mockConn.On("PublishMsg", mock.MatchedBy(
+					matchFGAEnvelope(fgaconstants.GenericDeleteAccessSubject, "delete_access", "test-uid-to-delete"),
+				)).Return(nil)
 			},
-			setupCtx: backgroundCtx,
-			wantErr:  false,
-		},
-		{
-			name:    "unsupported message type",
-			subject: fgaconstants.GenericUpdateAccessSubject,
-			message: 123, // Invalid type - int is not supported
-			setupMocks: func(mockConn *MockNATSConn) {
-				// No publish expected
-			},
-			setupCtx: backgroundCtx,
-			wantErr:  true,
+			setupCtx:    backgroundCtx,
+			wantErr:     false,
+			verifyTrace: true,
 		},
 		{
 			name:    "nats publish error",
@@ -329,97 +381,20 @@ func TestMessageBuilder_PublishAccessMessage(t *testing.T) {
 					return msg.Subject == fgaconstants.GenericUpdateAccessSubject
 				})).Return(errors.New("nats error"))
 			},
-			setupCtx: backgroundCtx,
-			wantErr:  true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockConn := &MockNATSConn{}
-			tt.setupMocks(mockConn)
-
-			mb := &MessageBuilder{
-				NatsConn: mockConn,
-			}
-
-			ctx := tt.setupCtx()
-			err := mb.SendAccessMessage(ctx, tt.subject, tt.message, false)
-
-			if tt.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-
-			mockConn.AssertExpectations(t)
-		})
-	}
-}
-
-func TestMessageBuilder_PublishAccessMessage_Sync(t *testing.T) {
-	tests := []struct {
-		name       string
-		subject    string
-		message    interface{}
-		setupMocks func(*MockNATSConn)
-		setupCtx   func() context.Context
-		wantErr    bool
-	}{
-		{
-			name:    "successful sync send update access message",
-			subject: fgaconstants.GenericUpdateAccessSubject,
-			message: fgatypes.GenericFGAMessage{
-				ObjectType: "project",
-				Operation:  "update_access",
-				Data: fgatypes.GenericAccessData{
-					UID:    "test-uid",
-					Public: true,
-					Relations: map[string][]string{
-						"writer":  {"user1"},
-						"auditor": {"user2"},
-					},
-					References: map[string][]string{
-						"parent": {"project:parent-uid"},
-					},
-				},
-			},
-			setupMocks: func(mockConn *MockNATSConn) {
-				mockConn.On("RequestMsgWithContext", mock.Anything, mock.MatchedBy(func(msg *nats.Msg) bool {
-					return msg.Subject == fgaconstants.GenericUpdateAccessSubject
-				})).Return(&nats.Msg{Data: []byte("OK")}, nil)
-			},
-			setupCtx: backgroundCtx,
-			wantErr:  false,
+			setupCtx:         backgroundCtx,
+			wantErr:          true,
+			verifyFailureLog: true,
 		},
 		{
-			name:    "successful sync send delete access message",
+			name:    "marshal error",
 			subject: fgaconstants.GenericDeleteAccessSubject,
 			message: fgatypes.GenericFGAMessage{
 				ObjectType: "project",
 				Operation:  "delete_access",
-				Data: fgatypes.GenericDeleteData{
-					UID: "test-uid-to-delete",
-				},
+				Data:       make(chan int),
 			},
 			setupMocks: func(mockConn *MockNATSConn) {
-				mockConn.On("RequestMsgWithContext", mock.Anything, mock.MatchedBy(func(msg *nats.Msg) bool {
-					return msg.Subject == fgaconstants.GenericDeleteAccessSubject
-				})).Return(&nats.Msg{Data: []byte("OK")}, nil)
-			},
-			setupCtx: backgroundCtx,
-			wantErr:  false,
-		},
-		{
-			name:    "nats request error - sync mode",
-			subject: fgaconstants.GenericUpdateAccessSubject,
-			message: fgatypes.GenericFGAMessage{
-				ObjectType: "project",
-				Operation:  "update_access",
-				Data:       fgatypes.GenericAccessData{UID: "test"},
-			},
-			setupMocks: func(mockConn *MockNATSConn) {
-				mockConn.On("RequestMsgWithContext", mock.Anything, mock.AnythingOfType("*nats.Msg")).Return(nil, errors.New("nats request timeout"))
+				// No publish expected when JSON marshalling fails.
 			},
 			setupCtx: backgroundCtx,
 			wantErr:  true,
@@ -428,6 +403,17 @@ func TestMessageBuilder_PublishAccessMessage_Sync(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			spansBefore := len(spanRecorder.Ended())
+
+			var logs bytes.Buffer
+			if tt.verifyFailureLog {
+				previousLogger := slog.Default()
+				slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+				t.Cleanup(func() {
+					slog.SetDefault(previousLogger)
+				})
+			}
+
 			mockConn := &MockNATSConn{}
 			tt.setupMocks(mockConn)
 
@@ -436,7 +422,7 @@ func TestMessageBuilder_PublishAccessMessage_Sync(t *testing.T) {
 			}
 
 			ctx := tt.setupCtx()
-			err := mb.SendAccessMessage(ctx, tt.subject, tt.message, true)
+			err := mb.PublishAccessMessage(ctx, tt.subject, tt.message)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -445,6 +431,19 @@ func TestMessageBuilder_PublishAccessMessage_Sync(t *testing.T) {
 			}
 
 			mockConn.AssertExpectations(t)
+
+			if tt.verifyTrace {
+				require.NoError(t, accessMessageTracerProvider.ForceFlush(context.Background()))
+				spans := spanRecorder.Ended()
+				require.Len(t, spans, spansBefore+1)
+				newSpan := spans[len(spans)-1]
+				assert.Equal(t, "nats.publish", newSpan.Name())
+				assert.Equal(t, oteltrace.SpanKindProducer, newSpan.SpanKind())
+			}
+
+			if tt.verifyFailureLog {
+				assert.Contains(t, logs.String(), "subject="+tt.subject)
+			}
 		})
 	}
 }

--- a/internal/service/project_operations.go
+++ b/internal/service/project_operations.go
@@ -206,7 +206,7 @@ func (s *ProjectsService) CreateProject(ctx context.Context, payload *projsvc.Cr
 
 	g.Go(func() error {
 		msg := buildFGAUpdateAccessMessage(projectDB, projectSettingsDB)
-		return s.MessageBuilder.SendAccessMessage(ctx, fgaconstants.GenericUpdateAccessSubject, msg, runSync)
+		return s.MessageBuilder.PublishAccessMessage(ctx, fgaconstants.GenericUpdateAccessSubject, msg)
 	})
 
 	if err := g.Wait(); err != nil {
@@ -473,7 +473,7 @@ func (s *ProjectsService) UpdateProjectBase(ctx context.Context, payload *projsv
 
 	g.Go(func() error {
 		msg := buildFGAUpdateAccessMessage(projectDB, projectSettingsDB)
-		return s.MessageBuilder.SendAccessMessage(ctx, fgaconstants.GenericUpdateAccessSubject, msg, runSync)
+		return s.MessageBuilder.PublishAccessMessage(ctx, fgaconstants.GenericUpdateAccessSubject, msg)
 	})
 
 	if err := g.Wait(); err != nil {
@@ -616,7 +616,7 @@ func (s *ProjectsService) UpdateProjectSettings(ctx context.Context, payload *pr
 
 	g.Go(func() error {
 		msg := buildFGAUpdateAccessMessage(projectDB, projectSettingsDB)
-		return s.MessageBuilder.SendAccessMessage(ctx, fgaconstants.GenericUpdateAccessSubject, msg, runSync)
+		return s.MessageBuilder.PublishAccessMessage(ctx, fgaconstants.GenericUpdateAccessSubject, msg)
 	})
 
 	g.Go(func() error {
@@ -741,7 +741,7 @@ func (s *ProjectsService) DeleteProject(ctx context.Context, payload *projsvc.De
 				UID: *payload.UID,
 			},
 		}
-		return s.MessageBuilder.SendAccessMessage(ctx, fgaconstants.GenericDeleteAccessSubject, msg, runSync)
+		return s.MessageBuilder.PublishAccessMessage(ctx, fgaconstants.GenericDeleteAccessSubject, msg)
 	})
 
 	if err := g.Wait(); err != nil {

--- a/internal/service/project_operations_test.go
+++ b/internal/service/project_operations_test.go
@@ -152,12 +152,24 @@ func TestProjectsService_CreateProject(t *testing.T) {
 				Public:      misc.BoolPtr(true),
 				Stage:       misc.StringPtr("incubating"),
 				Category:    misc.StringPtr("foundation"),
+				XSync:       misc.BoolPtr(true),
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
 				mockRepo.On("ProjectSlugExists", mock.Anything, "test-project").Return(false, nil)
 				mockRepo.On("CreateProject", mock.Anything, mock.AnythingOfType("*models.ProjectBase"), mock.AnythingOfType("*models.ProjectSettings")).Return(nil)
-				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.IndexerMessageEnvelope"), mock.AnythingOfType("bool")).Return(nil).Times(2)
-				mockBuilder.On("SendAccessMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.GenericFGAMessage"), mock.AnythingOfType("bool")).Return(nil)
+				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.IndexerMessageEnvelope"), true).Return(nil).Times(2)
+				mockBuilder.On("PublishAccessMessage",
+					mock.Anything,
+					"lfx.fga-sync.update_access",
+					mock.MatchedBy(func(msg fgatypes.GenericFGAMessage) bool {
+						data, ok := msg.Data.(fgatypes.GenericAccessData)
+						return ok &&
+							msg.ObjectType == "project" &&
+							msg.Operation == "update_access" &&
+							data.UID != "" &&
+							data.Public
+					}),
+				).Return(nil)
 			},
 			wantErr: false,
 			validate: func(t *testing.T, result *projsvc.ProjectFull) {
@@ -168,6 +180,21 @@ func TestProjectsService_CreateProject(t *testing.T) {
 				assert.Equal(t, "Test Description", *result.Description)
 				assert.Equal(t, true, *result.Public)
 			},
+		},
+		{
+			name: "FGA publish failure after repository creation returns internal error",
+			payload: &projsvc.CreateProjectPayload{
+				Slug: "publish-failure",
+				Name: "Publish Failure",
+			},
+			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
+				mockRepo.On("ProjectSlugExists", mock.Anything, "publish-failure").Return(false, nil)
+				mockRepo.On("CreateProject", mock.Anything, mock.AnythingOfType("*models.ProjectBase"), mock.AnythingOfType("*models.ProjectSettings")).Return(nil).Once()
+				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, false).Return(nil).Times(2)
+				mockBuilder.On("PublishAccessMessage", mock.Anything, "lfx.fga-sync.update_access", mock.AnythingOfType("types.GenericFGAMessage")).Return(domain.ErrInternal).Once()
+			},
+			wantErr:     true,
+			expectedErr: domain.ErrInternal,
 		},
 		{
 			name: "service not ready",
@@ -242,12 +269,13 @@ func TestProjectsService_CreateProject(t *testing.T) {
 				Description:           "Desc",
 				Stage:                 misc.StringPtr("Archived"),
 				EntityDissolutionDate: misc.StringPtr("2021-12-31"),
+				XSync:                 misc.BoolPtr(false),
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
 				mockRepo.On("ProjectSlugExists", mock.Anything, "archived-with-date").Return(false, nil)
 				mockRepo.On("CreateProject", mock.Anything, mock.AnythingOfType("*models.ProjectBase"), mock.AnythingOfType("*models.ProjectSettings")).Return(nil)
-				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.IndexerMessageEnvelope"), mock.AnythingOfType("bool")).Return(nil).Times(2)
-				mockBuilder.On("SendAccessMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.GenericFGAMessage"), mock.AnythingOfType("bool")).Return(nil)
+				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.IndexerMessageEnvelope"), false).Return(nil).Times(2)
+				mockBuilder.On("PublishAccessMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.GenericFGAMessage")).Return(nil)
 			},
 			wantErr: false,
 			validate: func(t *testing.T, result *projsvc.ProjectFull) {
@@ -287,8 +315,8 @@ func TestProjectsService_CreateProject(t *testing.T) {
 				mockRepo.On("CreateProject", mock.Anything, mock.AnythingOfType("*models.ProjectBase"), mock.MatchedBy(func(s *models.ProjectSettings) bool {
 					return len(s.Writers) == 1 && s.Writers[0].Username == "carol-lfid"
 				})).Return(nil)
-				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(2)
-				mockBuilder.On("SendAccessMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, false).Return(nil).Times(2)
+				mockBuilder.On("PublishAccessMessage", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: false,
 			validate: func(t *testing.T, result *projsvc.ProjectFull) {
@@ -456,6 +484,7 @@ func TestProjectsService_DeleteProject(t *testing.T) {
 			payload: &projsvc.DeleteProjectPayload{
 				UID:     misc.StringPtr("test-project-uid"),
 				IfMatch: misc.StringPtr("123"),
+				XSync:   misc.BoolPtr(true),
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
 				// Project has Crowdfunding in funding model - deletion allowed
@@ -469,14 +498,36 @@ func TestProjectsService_DeleteProject(t *testing.T) {
 					nil,
 				)
 				mockRepo.On("DeleteProject", mock.Anything, "test-project-uid", uint64(123)).Return(nil)
-				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.AnythingOfType("string"), "test-project-uid", mock.AnythingOfType("bool")).Return(nil).Times(2)
-				mockBuilder.On("SendAccessMessage", mock.Anything, mock.AnythingOfType("string"), fgatypes.GenericFGAMessage{
+				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.AnythingOfType("string"), "test-project-uid", true).Return(nil).Times(2)
+				mockBuilder.On("PublishAccessMessage", mock.Anything, "lfx.fga-sync.delete_access", fgatypes.GenericFGAMessage{
 					ObjectType: "project",
 					Operation:  "delete_access",
 					Data:       fgatypes.GenericDeleteData{UID: "test-project-uid"},
-				}, mock.AnythingOfType("bool")).Return(nil)
+				}).Return(nil)
 			},
 			wantErr: false,
+		},
+		{
+			name: "FGA publish failure after repository deletion returns internal error",
+			payload: &projsvc.DeleteProjectPayload{
+				UID:     misc.StringPtr("test-project-uid"),
+				IfMatch: misc.StringPtr("123"),
+				XSync:   misc.BoolPtr(false),
+			},
+			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
+				mockRepo.On("GetProjectBase", mock.Anything, "test-project-uid").Return(
+					&models.ProjectBase{
+						UID:          "test-project-uid",
+						FundingModel: []string{"Crowdfunding"},
+					},
+					nil,
+				)
+				mockRepo.On("DeleteProject", mock.Anything, "test-project-uid", uint64(123)).Return(nil).Once()
+				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.AnythingOfType("string"), "test-project-uid", false).Return(nil).Times(2)
+				mockBuilder.On("PublishAccessMessage", mock.Anything, "lfx.fga-sync.delete_access", mock.AnythingOfType("types.GenericFGAMessage")).Return(domain.ErrInternal).Once()
+			},
+			wantErr:     true,
+			expectedErr: domain.ErrInternal,
 		},
 		{
 			name: "deletion rejected - project with Crowdfunding and other funding models",
@@ -639,12 +690,12 @@ func TestProjectsService_DeleteProject(t *testing.T) {
 					nil,
 				)
 				mockRepo.On("DeleteProject", mock.Anything, "test-project-uid", uint64(456)).Return(nil)
-				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.AnythingOfType("string"), "test-project-uid", mock.AnythingOfType("bool")).Return(nil).Times(2)
-				mockBuilder.On("SendAccessMessage", mock.Anything, mock.AnythingOfType("string"), fgatypes.GenericFGAMessage{
+				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.AnythingOfType("string"), "test-project-uid", false).Return(nil).Times(2)
+				mockBuilder.On("PublishAccessMessage", mock.Anything, "lfx.fga-sync.delete_access", fgatypes.GenericFGAMessage{
 					ObjectType: "project",
 					Operation:  "delete_access",
 					Data:       fgatypes.GenericDeleteData{UID: "test-project-uid"},
-				}, mock.AnythingOfType("bool")).Return(nil)
+				}).Return(nil)
 			},
 			wantErr: false,
 		},
@@ -791,6 +842,7 @@ func TestProjectsService_UpdateProjectBase(t *testing.T) {
 				Slug:    "test-project",
 				Name:    "Test Project",
 				Public:  misc.BoolPtr(true),
+				XSync:   misc.BoolPtr(true),
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
 				projectDB := &models.ProjectBase{
@@ -805,8 +857,8 @@ func TestProjectsService_UpdateProjectBase(t *testing.T) {
 				mockRepo.On("GetProjectBase", mock.Anything, "project-uid-1").Return(projectDB, nil)
 				mockRepo.On("UpdateProjectBase", mock.Anything, mock.AnythingOfType("*models.ProjectBase"), uint64(1)).Return(nil)
 				mockRepo.On("GetProjectSettings", mock.Anything, "project-uid-1").Return(settingsDB, nil)
-				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.IndexerMessageEnvelope"), mock.AnythingOfType("bool")).Return(nil)
-				mockBuilder.On("SendAccessMessage",
+				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.IndexerMessageEnvelope"), true).Return(nil)
+				mockBuilder.On("PublishAccessMessage",
 					mock.Anything,
 					"lfx.fga-sync.update_access",
 					fgatypes.GenericFGAMessage{
@@ -819,7 +871,6 @@ func TestProjectsService_UpdateProjectBase(t *testing.T) {
 							References: make(map[string][]string),
 						},
 					},
-					mock.AnythingOfType("bool"),
 				).Return(nil)
 			},
 			wantErr: false,
@@ -836,6 +887,7 @@ func TestProjectsService_UpdateProjectBase(t *testing.T) {
 				Slug:      "child-project",
 				Name:      "Child Project",
 				ParentUID: "11111111-2222-3333-4444-555555555555",
+				XSync:     misc.BoolPtr(false),
 			},
 			setupMocks: func(mockRepo *domain.MockProjectRepository, mockBuilder *domain.MockMessageBuilder) {
 				projectDB := &models.ProjectBase{
@@ -849,8 +901,8 @@ func TestProjectsService_UpdateProjectBase(t *testing.T) {
 				mockRepo.On("ProjectExists", mock.Anything, "11111111-2222-3333-4444-555555555555").Return(true, nil)
 				mockRepo.On("UpdateProjectBase", mock.Anything, mock.AnythingOfType("*models.ProjectBase"), uint64(5)).Return(nil)
 				mockRepo.On("GetProjectSettings", mock.Anything, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").Return(settingsDB, nil)
-				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.IndexerMessageEnvelope"), mock.AnythingOfType("bool")).Return(nil)
-				mockBuilder.On("SendAccessMessage",
+				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.IndexerMessageEnvelope"), false).Return(nil)
+				mockBuilder.On("PublishAccessMessage",
 					mock.Anything,
 					"lfx.fga-sync.update_access",
 					fgatypes.GenericFGAMessage{
@@ -863,7 +915,6 @@ func TestProjectsService_UpdateProjectBase(t *testing.T) {
 							References: map[string][]string{"parent": {"project:11111111-2222-3333-4444-555555555555"}},
 						},
 					},
-					mock.AnythingOfType("bool"),
 				).Return(nil)
 			},
 			wantErr: false,
@@ -920,8 +971,8 @@ func TestProjectsService_UpdateProjectBase(t *testing.T) {
 				mockRepo.On("GetProjectBase", mock.Anything, "project-uid-1").Return(projectDB, nil)
 				mockRepo.On("UpdateProjectBase", mock.Anything, mock.AnythingOfType("*models.ProjectBase"), uint64(1)).Return(nil)
 				mockRepo.On("GetProjectSettings", mock.Anything, "project-uid-1").Return(settingsDB, nil)
-				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.IndexerMessageEnvelope"), mock.AnythingOfType("bool")).Return(nil)
-				mockBuilder.On("SendAccessMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.GenericFGAMessage"), mock.AnythingOfType("bool")).Return(nil)
+				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.IndexerMessageEnvelope"), false).Return(nil)
+				mockBuilder.On("PublishAccessMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.GenericFGAMessage")).Return(nil)
 			},
 			wantErr: false,
 			validate: func(t *testing.T, result *projsvc.ProjectBase) {
@@ -945,7 +996,7 @@ func TestProjectsService_UpdateProjectBase(t *testing.T) {
 				mockRepo.On("UpdateProjectBase", mock.Anything, mock.AnythingOfType("*models.ProjectBase"), uint64(1)).Return(nil)
 				mockRepo.On("GetProjectSettings", mock.Anything, "project-uid-1").Return(settingsDB, nil)
 				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.IndexerMessageEnvelope"), mock.AnythingOfType("bool")).Return(nil)
-				mockBuilder.On("SendAccessMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.GenericFGAMessage"), mock.AnythingOfType("bool")).Return(nil)
+				mockBuilder.On("PublishAccessMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.GenericFGAMessage")).Return(nil)
 			},
 			wantErr: false,
 		},
@@ -997,6 +1048,7 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 			payload: &projsvc.UpdateProjectSettingsPayload{
 				UID:     misc.StringPtr("project-uid-1"),
 				IfMatch: misc.StringPtr("3"),
+				XSync:   misc.BoolPtr(true),
 				Writers: []*projsvc.UserInfo{
 					{Username: misc.StringPtr("alice"), Name: misc.StringPtr("Alice"), Email: misc.StringPtr("alice@example.com"), Avatar: misc.StringPtr("")},
 				},
@@ -1019,12 +1071,11 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				mockRepo.On("GetProjectBase", mock.Anything, "project-uid-1").Return(projectDB, nil)
 				// After update, GetProjectSettings is called again to build the FGA message — use updated settings
 				mockRepo.On("GetProjectSettings", mock.Anything, "project-uid-1").Return(updatedSettings, nil).Maybe()
-				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.IndexerMessageEnvelope"), mock.AnythingOfType("bool")).Return(nil)
-				mockBuilder.On("SendAccessMessage",
+				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("types.IndexerMessageEnvelope"), true).Return(nil)
+				mockBuilder.On("PublishAccessMessage",
 					mock.Anything,
 					"lfx.fga-sync.update_access",
 					mock.AnythingOfType("types.GenericFGAMessage"),
-					mock.AnythingOfType("bool"),
 				).Return(nil).Run(func(args mock.Arguments) {
 					msg, ok := args.Get(2).(fgatypes.GenericFGAMessage)
 					require.True(t, ok)
@@ -1033,6 +1084,7 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 					data, ok := msg.Data.(fgatypes.GenericAccessData)
 					require.True(t, ok)
 					assert.Equal(t, "project-uid-1", data.UID)
+					assert.Equal(t, []string{"alice"}, data.Relations["writer"])
 				})
 				mockBuilder.On("SendProjectEventMessage", mock.Anything, mock.AnythingOfType("string"), mock.Anything).Return(nil)
 			},
@@ -1043,6 +1095,7 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 			payload: &projsvc.UpdateProjectSettingsPayload{
 				UID:     misc.StringPtr("project-uid-1"),
 				IfMatch: misc.StringPtr("1"),
+				XSync:   misc.BoolPtr(false),
 				Writers: []*projsvc.UserInfo{
 					{Username: misc.StringPtr("UNTRUSTED"), Name: misc.StringPtr("Bob"), Email: misc.StringPtr("bob@example.com")},
 				},
@@ -1060,8 +1113,8 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 					return len(s.Writers) == 1 && s.Writers[0].Username == "real-bob"
 				}), uint64(1)).Return(nil)
 				mockRepo.On("GetProjectBase", mock.Anything, "project-uid-1").Return(projectDB, nil)
-				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				mockBuilder.On("SendAccessMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, false).Return(nil)
+				mockBuilder.On("PublishAccessMessage", mock.Anything, "lfx.fga-sync.update_access", mock.AnythingOfType("types.GenericFGAMessage")).Return(nil)
 				mockBuilder.On("SendProjectEventMessage", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: false,
@@ -1087,8 +1140,8 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 					return len(s.Writers) == 1 && s.Writers[0].Username == ""
 				}), uint64(1)).Return(nil)
 				mockRepo.On("GetProjectBase", mock.Anything, "project-uid-1").Return(projectDB, nil)
-				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				mockBuilder.On("SendAccessMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, false).Return(nil)
+				mockBuilder.On("PublishAccessMessage", mock.Anything, "lfx.fga-sync.update_access", mock.AnythingOfType("types.GenericFGAMessage")).Return(nil)
 				mockBuilder.On("SendProjectEventMessage", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: false,
@@ -1112,7 +1165,7 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				}), uint64(1)).Return(nil)
 				mockRepo.On("GetProjectBase", mock.Anything, "project-uid-1").Return(projectDB, nil)
 				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				mockBuilder.On("SendAccessMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("PublishAccessMessage", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				mockBuilder.On("SendProjectEventMessage", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: false,
@@ -1168,7 +1221,7 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				}), uint64(1)).Return(nil)
 				mockRepo.On("GetProjectBase", mock.Anything, "project-uid-1").Return(projectDB, nil)
 				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				mockBuilder.On("SendAccessMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("PublishAccessMessage", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				mockBuilder.On("SendProjectEventMessage", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: false,
@@ -1195,7 +1248,7 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				}), uint64(1)).Return(nil)
 				mockRepo.On("GetProjectBase", mock.Anything, "project-uid-1").Return(projectDB, nil)
 				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				mockBuilder.On("SendAccessMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("PublishAccessMessage", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				mockBuilder.On("SendProjectEventMessage", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: false,
@@ -1230,7 +1283,7 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				}), uint64(1)).Return(nil)
 				mockRepo.On("GetProjectBase", mock.Anything, "project-uid-1").Return(projectDB, nil)
 				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				mockBuilder.On("SendAccessMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("PublishAccessMessage", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				mockBuilder.On("SendProjectEventMessage", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: false,
@@ -1262,7 +1315,7 @@ func TestProjectsService_UpdateProjectSettings(t *testing.T) {
 				}), uint64(1)).Return(nil)
 				mockRepo.On("GetProjectBase", mock.Anything, "project-uid-1").Return(projectDB, nil)
 				mockBuilder.On("SendIndexerMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				mockBuilder.On("SendAccessMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("PublishAccessMessage", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				mockBuilder.On("SendProjectEventMessage", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: false,


### PR DESCRIPTION
## Summary

Removes synchronous FGA `update_access`/`delete_access` publishing from the project service.

- Replaced the sync-capable `SendAccessMessage(ctx, subject, message any, sync bool)` with an async-only, strongly-typed `PublishAccessMessage(ctx, subject, message fgatypes.GenericFGAMessage) error` in the `MessageBuilder` interface, mock, and NATS implementation. It always resolves to `PublishMsg` and never `RequestMsgWithContext`.
- Moved all four FGA publish call sites (`CreateProject`, `UpdateProjectBase`, `UpdateProjectSettings`, `DeleteProject`) to `PublishAccessMessage`. Indexer messages (`lfx.index.project`, `lfx.index.project_settings`) continue to honor caller-derived `X-Sync` independently — `X-Sync` no longer blocks the HTTP response on FGA/OpenFGA convergence.
- Documented the revised `X-Sync` boundary in `docs/fga-contract.md`.
- Updated all affected unit tests: mock expectations, `X-Sync` scenario coverage (true/false/absent), FGA-publish-failure cases, and merged three separate `PublishAccessMessage` test functions into one table-driven test (this repo's testing convention is one test function per production function). Also fixed a discovered test-isolation bug around OpenTelemetry's global tracer provider (it only performs a one-time delegate upgrade for already-resolved `Tracer` handles, so repeated `SetTracerProvider` calls across subtests/`-count=N` silently no-op) by installing the tracer provider once via `sync.Once` and asserting span-count deltas.

## Why

`X-Sync: true` previously made FGA `update_access`/`delete_access` publishing block on NATS request/reply. That coupled indexer synchronization guarantees to OpenFGA convergence, which the current core-NATS FGA consumer does not actually guarantee (no ack/response contract). Publishing is now always fire-and-forget, while indexer synchronization remains controllable via `X-Sync` as before.

## Testing

- `gofmt -l .`, `go build ./...`, `go vet ./...`, `go test -race ./...`, `golangci-lint run ./...` all clean (0 issues).
- Live end-to-end verification against a dev EKS cluster (NATS port-forward, local `project-api` binary, and the real `fga-sync` consumer/OpenFGA store already running there — not mocks):

  | # | Scenario | X-Sync | HTTP Status | FGA delivery mode | fga-sync processed | Result |
  |---|----------|--------|--------------|--------------------|---------------------|--------|
  | 1 | POST /projects (create) | true | 201 | `nats.Publish` (async) | tuple written | ✅ |
  | 2 | PUT /projects/:uid (update base) | false | 200 | `nats.Publish` (async) | tuple written | ✅ |
  | 3 | PUT /projects/:uid/settings (update settings) | true | 200 | `nats.Publish` (async) | tuple written | ✅ |
  | 4 | DELETE /projects/:uid (delete) | true | 204 | `nats.Publish` (async) | tuple deleted | ✅ |
  | 5 | Cleanup via `admin-delete-project` script | n/a | n/a | indexer sync deletes | n/a | ✅ |

  <details>
  <summary>Full live-testing evidence log (dev cluster, redacted)</summary>

  **Environment:** dev EKS cluster, NATS port-forwarded from `svc/lfx-platform-nats`. Local `project-api` binary built from this branch, connected to dev NATS, mock auth enabled. FGA consumer: the real `lfx-v2-fga-sync` deployment already running in the dev cluster, consuming from the same NATS instance and writing to the dev OpenFGA store.

  Context safety check performed before any writes: confirmed the active `kubectl` context was the dev cluster (distinct account from prod), and the port-forward was only started after switching to the dev context.

  ---

  ### 1. CreateProject — `X-Sync: true`

  ```
  POST /projects
  {"slug":"lfxv2-2830-evidence-1","name":"LFXV2-2830 Evidence Sync True", ...}

  Response (HTTP 201): {"uid":"<redacted-uuid-1>", ...}
  ```

  **project-api debug log:**
  ```
  PublishAccessMessage  msg="sent message to NATS asynchronously"  subject=lfx.fga-sync.update_access
  sendMessage           msg="sent and received response from NATS synchronously"  subject=lfx.index.project_settings
  sendMessage           msg="sent and received response from NATS synchronously"  subject=lfx.index.project
  ```

  **NATS subscriber (`lfx.fga-sync.>`):**
  ```
  [#1] Received on "lfx.fga-sync.update_access"
  {"object_type":"project","operation":"update_access","data":{"uid":"<redacted-uuid-1>","public":true,"relations":{},"references":{},"exclude_relations":null}}
  ```

  **`lfx-v2-fga-sync` pod log (real dev consumer):**
  ```
  handling generic update_access        object_type=project  uid=<redacted-uuid-1>
  handling project access control update
  will add relation in batch write      user=user:*  relation=viewer  object=project:<redacted-uuid-1>
  wrote and deleted tuples              writes_count=1  deletes_count=0
  synced tuples                         object=project:<redacted-uuid-1>
  ```

  ✅ **PASS** — FGA publish is `nats.Publish` (async, fire-and-forget) even though `X-Sync: true`; indexer messages are sent synchronously as before. The real dev `fga-sync` consumer received the message and wrote the `viewer` tuple to OpenFGA.

  ---

  ### 2. UpdateProjectBase — `X-Sync: false`

  ```
  PUT /projects/<redacted-uuid-1>
  {"slug":"lfxv2-2830-evidence-1","name":"LFXV2-2830 Evidence Updated", ...}

  Response (HTTP 200): {"uid":"<redacted-uuid-1>", "name":"LFXV2-2830 Evidence Updated", ...}
  ```

  ✅ **PASS** — Update succeeded; `PublishAccessMessage` invoked identically regardless of `X-Sync` value.

  ---

  ### 3. UpdateProjectSettings — `X-Sync: true`

  ```
  PUT /projects/<redacted-uuid-1>/settings
  {"mission_statement":"live testing evidence settings update", ...}

  Response (HTTP 200): {"uid":"<redacted-uuid-1>","mission_statement":"live testing evidence settings update", ...}
  ```

  ✅ **PASS** — Settings update triggers another `update_access` publish (subscriber capture confirms `object_type=project`, same `uid`).

  ---

  ### 4. DeleteProject — `X-Sync: true` (Crowdfunding-only funding model required)

  Setup: created a project with `funding_model:["Crowdfunding"]` (required by existing delete validation), then deleted it.

  ```
  POST /projects {"slug":"lfxv2-2830-evidence-4-delete", ..., "funding_model":["Crowdfunding"]}
  Response (HTTP 201): {"uid":"<redacted-uuid-2>", ...}

  DELETE /projects/<redacted-uuid-2>
  X-Sync: true
  Response: HTTP 204
  ```

  **project-api debug log (delete path):**
  ```
  sendIndexerMessage     constructed indexer message  subject=lfx.index.project_settings  action=deleted
  sendIndexerMessage     constructed indexer message  subject=lfx.index.project           action=deleted
  PublishAccessMessage   "sent message to NATS asynchronously"                subject=lfx.fga-sync.delete_access
  sendMessage            "sent and received response from NATS synchronously" subject=lfx.index.project
  sendMessage            "sent and received response from NATS synchronously" subject=lfx.index.project_settings
  DeleteProject          "deleted project"  project_uid=<redacted-uuid-2>
  ```

  **NATS subscriber (`lfx.fga-sync.>`):**
  ```
  [#7] Received on "lfx.fga-sync.delete_access"
  {"object_type":"project","operation":"delete_access","data":{"uid":"<redacted-uuid-2>"}}
  ```

  **`lfx-v2-fga-sync` pod log (real dev consumer):**
  ```
  handling generic delete_access         object_type=project  uid=<redacted-uuid-2>
  will delete relation in batch write    user=user:*  relation=viewer  object=project:<redacted-uuid-2>
  wrote and deleted tuples               writes_count=0  deletes_count=1
  deleted all access for project         object=project:<redacted-uuid-2>
  ```

  ✅ **PASS** — `delete_access` is published asynchronously via `PublishAccessMessage`/`nats.Publish` (indexer deletes remain synchronous per `X-Sync: true`), consumed by the real dev `fga-sync` service, and the OpenFGA `viewer` tuple was deleted. HTTP response (204) returned in ~1.9s without waiting on FGA processing.

  ---

  ### Cleanup

  Remaining evidence-run projects (non-Crowdfunding, so not deletable via the public API) were removed with the existing `admin-delete-project` script against the same dev NATS port-forward. Post-cleanup verification confirmed all KV records absent (`nats kv get` → key not found for all three UIDs). Dev cluster left clean, no residual test data.

  </details>


Made with [Cursor](https://cursor.com)