### PR TITLE
fix: reconcile projects bucket slug index in rename-project-slug migration

### DIFF
--- a/cmd/project-cli/README.md
+++ b/cmd/project-cli/README.md
@@ -40,6 +40,8 @@ These env vars are read in `main` and passed to subcommands via `RunContext`. Su
 
 Renames a project slug across **both** OpenSearch (`resources` index) and NATS JetStream KV buckets in a single run. Connects to NATS and OpenSearch at the start of `Run()`. OpenSearch is updated first, then NATS KV.
 
+For the `projects` bucket, the migration also keeps the secondary `slug/<slug>` -> uid lookup index (used by `GetProjectUIDFromSlug` and the `lfx.projects-api.slug_to_uid` NATS RPC) in sync with the record's `slug` field. Reconciliation is driven off each record's **observed current slug**, not whether the current run performed the field write, so a record left inconsistent by a prior partial failure (field renamed, index still stale) is repaired on rerun instead of becoming permanently unresolvable. A pre-flight check fails the operation for a given record (without mutating it) if `slug/<newSlug>` already resolves to a different project.
+
 **Subcommand flags**
 
 | Flag | Default | Description |

--- a/cmd/project-cli/commands/sync/rename_project_slug_runner.go
+++ b/cmd/project-cli/commands/sync/rename_project_slug_runner.go
@@ -24,12 +24,22 @@ import (
 
 var errSlugMismatch = errors.New("project_slug does not match old slug")
 
+// errSlugIndexCollision indicates the new slug's lookup index already points
+// at a different project than the one being renamed.
+var errSlugIndexCollision = errors.New("new slug is already indexed to a different project")
+
+// projectsBucket is the only bucket that carries a "slug/<slug>" -> uid
+// lookup index (see GetProjectUIDFromSlug in internal/infrastructure/nats),
+// which needs its own reconciliation logic distinct from the plain
+// field-rename path used by every other bucket.
+const projectsBucket = "projects"
+
 // DefaultNATSBuckets are the KV buckets scanned during a slug rename migration.
 var DefaultNATSBuckets = []string{
 	"committee-members",
 	"committees",
 	"committee-settings",
-	"projects",
+	projectsBucket,
 	"project-settings",
 }
 
@@ -39,7 +49,7 @@ var bucketSlugFields = map[string][]string{
 	"committee-members":  {"project_slug"},
 	"committees":         {"project_slug"},
 	"committee-settings": {"project_slug"},
-	"projects":           {"slug"},
+	projectsBucket:       {"slug"},
 	"project-settings":   {"project_slug"},
 }
 
@@ -419,7 +429,12 @@ func (r *RenameSlugRunner) migrateBucket(ctx context.Context, bucket, oldSlug, n
 	for _, key := range recordKeys {
 		key := key
 		g.Go(func() error {
-			err := processKVRecord(gCtx, kvStore, key, fields, oldSlug, newSlug, dryRun)
+			var err error
+			if bucket == projectsBucket {
+				err = processProjectRecord(gCtx, kvStore, key, fields, oldSlug, newSlug, dryRun)
+			} else {
+				err = processKVRecord(gCtx, kvStore, key, fields, oldSlug, newSlug, dryRun)
+			}
 
 			statsMu.Lock()
 			if err != nil {
@@ -457,7 +472,18 @@ func (r *RenameSlugRunner) migrateBucket(ctx context.Context, bucket, oldSlug, n
 	return stats, nil
 }
 
-func processKVRecord(ctx context.Context, kvStore jetstream.KeyValue, key string, fields []string, oldSlug, newSlug string, dryRun bool) error {
+// recordKV is the subset of jetstream.KeyValue needed by processKVRecord and
+// processProjectRecord to read/update a record and reconcile the projects
+// bucket's slug index. Narrowing it lets tests exercise the wiring with a
+// small fake instead of a full jetstream.KeyValue implementation.
+type recordKV interface {
+	Get(ctx context.Context, key string) (jetstream.KeyValueEntry, error)
+	Update(ctx context.Context, key string, value []byte, revision uint64) (uint64, error)
+	Put(ctx context.Context, key string, value []byte) (uint64, error)
+	Delete(ctx context.Context, key string, opts ...jetstream.KVDeleteOpt) error
+}
+
+func processKVRecord(ctx context.Context, kvStore recordKV, key string, fields []string, oldSlug, newSlug string, dryRun bool) error {
 	entry, err := kvStore.Get(ctx, key)
 	if err != nil {
 		return fmt.Errorf("failed to get entry: %w", err)
@@ -468,6 +494,14 @@ func processKVRecord(ctx context.Context, kvStore jetstream.KeyValue, key string
 		return fmt.Errorf("failed to unmarshal JSON: %w", err)
 	}
 
+	return updateSlugField(ctx, kvStore, key, fields, oldSlug, newSlug, dryRun, entry, raw)
+}
+
+// updateSlugField renames oldSlug to newSlug on an already-fetched record.
+// Callers that already hold the record's entry/raw JSON (e.g.
+// processProjectRecord, which fetches it to inspect the current slug) pass
+// them in directly to avoid a redundant re-fetch.
+func updateSlugField(ctx context.Context, kvStore recordKV, key string, fields []string, oldSlug, newSlug string, dryRun bool, entry jetstream.KeyValueEntry, raw map[string]json.RawMessage) error {
 	matched := false
 	for _, field := range fields {
 		val, ok := raw[field]
@@ -505,6 +539,7 @@ func processKVRecord(ctx context.Context, kvStore jetstream.KeyValue, key string
 	var updateErr error
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		if attempt > 1 {
+			var err error
 			entry, err = kvStore.Get(ctx, key)
 			if err != nil {
 				return fmt.Errorf("failed to re-fetch entry: %w", err)
@@ -567,6 +602,103 @@ func processKVRecord(ctx context.Context, kvStore jetstream.KeyValue, key string
 		return fmt.Errorf("failed to update after %d attempts: %w", maxRetries, updateErr)
 	}
 
+	return nil
+}
+
+// processProjectRecord handles the projects bucket's per-key dispatch. Unlike
+// processKVRecord (used by the other four buckets), it reconciles the slug
+// index off the record's observed current slug rather than off whether this
+// run performed the field write — so a record left inconsistent by a prior
+// partial failure (field already renamed, index still stale) is repaired on
+// rerun instead of becoming permanently invisible to the migration.
+func processProjectRecord(ctx context.Context, kvStore recordKV, key string, fields []string, oldSlug, newSlug string, dryRun bool) error {
+	entry, err := kvStore.Get(ctx, key)
+	if err != nil {
+		return fmt.Errorf("failed to get entry: %w", err)
+	}
+
+	raw := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(entry.Value(), &raw); err != nil {
+		return fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	currentSlug := ""
+	for _, field := range fields {
+		val, ok := raw[field]
+		if !ok {
+			continue
+		}
+		var s string
+		if err := json.Unmarshal(val, &s); err == nil {
+			currentSlug = s
+			break
+		}
+	}
+
+	// Pre-flight the collision check before mutating anything, so a colliding
+	// rename leaves both the record's field and the index untouched instead
+	// of renaming the field and then failing to reconcile the index.
+	switch currentSlug {
+	case oldSlug, newSlug:
+		if err := checkSlugIndexCollision(ctx, kvStore, key, newSlug); err != nil {
+			return err
+		}
+	default:
+		slog.DebugContext(ctx, "no matching slug field, skipping", "key", key)
+		return errSlugMismatch
+	}
+
+	if currentSlug == oldSlug {
+		if err := updateSlugField(ctx, kvStore, key, fields, oldSlug, newSlug, dryRun, entry, raw); err != nil {
+			return err
+		}
+	} else {
+		slog.DebugContext(ctx, "record already renamed, repairing slug index", "key", key)
+	}
+
+	return writeSlugIndex(ctx, kvStore, key, oldSlug, newSlug, dryRun)
+}
+
+// slugIndexKV is the subset of jetstream.KeyValue used by checkSlugIndexCollision and writeSlugIndex.
+type slugIndexKV interface {
+	Get(ctx context.Context, key string) (jetstream.KeyValueEntry, error)
+	Put(ctx context.Context, key string, value []byte) (uint64, error)
+	Delete(ctx context.Context, key string, opts ...jetstream.KVDeleteOpt) error
+}
+
+// checkSlugIndexCollision hard-fails if "slug/<newSlug>" already exists and
+// points at a uid other than the record being processed, so a rename never
+// silently clobbers another project's lookup mapping.
+func checkSlugIndexCollision(ctx context.Context, kv slugIndexKV, uid, newSlug string) error {
+	existing, err := kv.Get(ctx, "slug/"+newSlug)
+	switch {
+	case err == nil:
+		if string(existing.Value()) != uid {
+			return fmt.Errorf("%w: slug/%s is indexed to %q, not %q", errSlugIndexCollision, newSlug, existing.Value(), uid)
+		}
+		return nil
+	case errors.Is(err, jetstream.ErrKeyNotFound):
+		return nil
+	default:
+		return fmt.Errorf("failed to check slug index %q for collision: %w", newSlug, err)
+	}
+}
+
+// writeSlugIndex performs the actual index rename, assuming any collision
+// pre-flight has already passed.
+func writeSlugIndex(ctx context.Context, kv slugIndexKV, uid, oldSlug, newSlug string, dryRun bool) error {
+	if dryRun {
+		slog.InfoContext(ctx, "dry run: would reconcile slug index",
+			"uid", uid, "from", "slug/"+oldSlug, "to", "slug/"+newSlug)
+		return nil
+	}
+
+	if _, err := kv.Put(ctx, "slug/"+newSlug, []byte(uid)); err != nil {
+		return fmt.Errorf("failed to put slug index %q: %w", newSlug, err)
+	}
+	if err := kv.Delete(ctx, "slug/"+oldSlug); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+		return fmt.Errorf("failed to delete stale slug index %q: %w", oldSlug, err)
+	}
 	return nil
 }
 

--- a/cmd/project-cli/commands/sync/rename_project_slug_runner.go
+++ b/cmd/project-cli/commands/sync/rename_project_slug_runner.go
@@ -91,6 +91,13 @@ func NewRenameSlugRunner(openSearch *opensearchgo.Client, jetStream jetstream.Je
 }
 
 // Run renames oldSlug to newSlug across OpenSearch and NATS KV stores.
+//
+// The projects bucket's slug index reservation (reserveSlugIndex) only
+// guards against concurrent runs of this migration; it cannot protect
+// against project-api's own live writes, which use an unconditional Put for
+// slug mappings (see putProjectSlugMapping in internal/infrastructure/nats).
+// Run this migration only during a maintenance window with project-api
+// write traffic stopped.
 func (r *RenameSlugRunner) Run(ctx context.Context, opts RenameSlugOptions) error {
 	if opts.OldSlug == "" || opts.NewSlug == "" {
 		return fmt.Errorf("old slug and new slug are required")
@@ -710,17 +717,16 @@ func reserveSlugIndex(ctx context.Context, kv slugIndexKV, uid, newSlug string, 
 // between this check and the delete causes a conflict error instead of
 // losing that writer's mapping.
 func deleteOldSlugIndex(ctx context.Context, kv slugIndexKV, uid, oldSlug string, dryRun bool) error {
-	if dryRun {
-		slog.InfoContext(ctx, "dry run: would delete stale slug index", "uid", uid, "key", "slug/"+oldSlug)
-		return nil
-	}
-
 	existingOld, err := kv.Get(ctx, "slug/"+oldSlug)
 	switch {
 	case err == nil:
 		if string(existingOld.Value()) != uid {
 			slog.DebugContext(ctx, "stale slug index no longer owned by this project, leaving in place",
 				"uid", uid, "key", "slug/"+oldSlug)
+			return nil
+		}
+		if dryRun {
+			slog.InfoContext(ctx, "dry run: would delete stale slug index", "uid", uid, "key", "slug/"+oldSlug)
 			return nil
 		}
 		if err := kv.Delete(ctx, "slug/"+oldSlug, jetstream.LastRevision(existingOld.Revision())); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {

--- a/cmd/project-cli/commands/sync/rename_project_slug_runner.go
+++ b/cmd/project-cli/commands/sync/rename_project_slug_runner.go
@@ -479,7 +479,7 @@ func (r *RenameSlugRunner) migrateBucket(ctx context.Context, bucket, oldSlug, n
 type recordKV interface {
 	Get(ctx context.Context, key string) (jetstream.KeyValueEntry, error)
 	Update(ctx context.Context, key string, value []byte, revision uint64) (uint64, error)
-	Put(ctx context.Context, key string, value []byte) (uint64, error)
+	Create(ctx context.Context, key string, value []byte, opts ...jetstream.KVCreateOpt) (uint64, error)
 	Delete(ctx context.Context, key string, opts ...jetstream.KVDeleteOpt) error
 }
 
@@ -662,7 +662,7 @@ func processProjectRecord(ctx context.Context, kvStore recordKV, key string, fie
 // slugIndexKV is the subset of jetstream.KeyValue used by checkSlugIndexCollision and writeSlugIndex.
 type slugIndexKV interface {
 	Get(ctx context.Context, key string) (jetstream.KeyValueEntry, error)
-	Put(ctx context.Context, key string, value []byte) (uint64, error)
+	Create(ctx context.Context, key string, value []byte, opts ...jetstream.KVCreateOpt) (uint64, error)
 	Delete(ctx context.Context, key string, opts ...jetstream.KVDeleteOpt) error
 }
 
@@ -684,8 +684,14 @@ func checkSlugIndexCollision(ctx context.Context, kv slugIndexKV, uid, newSlug s
 	}
 }
 
-// writeSlugIndex performs the actual index rename, assuming any collision
-// pre-flight has already passed.
+// writeSlugIndex performs the actual index rename. checkSlugIndexCollision is
+// only a best-effort pre-flight and can race with a concurrent writer, so the
+// new key is reserved here with an atomic Create: if a concurrent writer won
+// the race and created "slug/<newSlug>" first, Create fails with
+// ErrKeyExists and the owning uid is re-checked instead of blindly
+// overwriting it. The old key is deleted only if it still maps to this uid,
+// so a concurrent writer that has since reused the old slug for another
+// project is not clobbered.
 func writeSlugIndex(ctx context.Context, kv slugIndexKV, uid, oldSlug, newSlug string, dryRun bool) error {
 	if dryRun {
 		slog.InfoContext(ctx, "dry run: would reconcile slug index",
@@ -693,11 +699,34 @@ func writeSlugIndex(ctx context.Context, kv slugIndexKV, uid, oldSlug, newSlug s
 		return nil
 	}
 
-	if _, err := kv.Put(ctx, "slug/"+newSlug, []byte(uid)); err != nil {
-		return fmt.Errorf("failed to put slug index %q: %w", newSlug, err)
+	if _, err := kv.Create(ctx, "slug/"+newSlug, []byte(uid)); err != nil {
+		if !errors.Is(err, jetstream.ErrKeyExists) {
+			return fmt.Errorf("failed to create slug index %q: %w", newSlug, err)
+		}
+		existing, getErr := kv.Get(ctx, "slug/"+newSlug)
+		if getErr != nil {
+			return fmt.Errorf("failed to verify slug index %q after create conflict: %w", newSlug, getErr)
+		}
+		if string(existing.Value()) != uid {
+			return fmt.Errorf("%w: slug/%s is indexed to %q, not %q", errSlugIndexCollision, newSlug, existing.Value(), uid)
+		}
 	}
-	if err := kv.Delete(ctx, "slug/"+oldSlug); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
-		return fmt.Errorf("failed to delete stale slug index %q: %w", oldSlug, err)
+
+	existingOld, err := kv.Get(ctx, "slug/"+oldSlug)
+	switch {
+	case err == nil:
+		if string(existingOld.Value()) != uid {
+			slog.DebugContext(ctx, "stale slug index no longer owned by this project, leaving in place",
+				"uid", uid, "key", "slug/"+oldSlug)
+			return nil
+		}
+		if err := kv.Delete(ctx, "slug/"+oldSlug); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+			return fmt.Errorf("failed to delete stale slug index %q: %w", oldSlug, err)
+		}
+	case errors.Is(err, jetstream.ErrKeyNotFound):
+		return nil
+	default:
+		return fmt.Errorf("failed to check slug index %q before delete: %w", oldSlug, err)
 	}
 	return nil
 }

--- a/cmd/project-cli/commands/sync/rename_project_slug_runner.go
+++ b/cmd/project-cli/commands/sync/rename_project_slug_runner.go
@@ -635,12 +635,14 @@ func processProjectRecord(ctx context.Context, kvStore recordKV, key string, fie
 		}
 	}
 
-	// Pre-flight the collision check before mutating anything, so a colliding
-	// rename leaves both the record's field and the index untouched instead
-	// of renaming the field and then failing to reconcile the index.
 	switch currentSlug {
 	case oldSlug, newSlug:
-		if err := checkSlugIndexCollision(ctx, kvStore, key, newSlug); err != nil {
+		// Reserve the new index key before touching the record's field, so a
+		// losing race (another writer claims "slug/<newSlug>" first) is
+		// caught before the field is renamed, instead of after — which would
+		// otherwise leave the field pointing at a slug now legitimately
+		// owned by another project.
+		if err := reserveSlugIndex(ctx, kvStore, key, newSlug, dryRun); err != nil {
 			return err
 		}
 	default:
@@ -656,47 +658,36 @@ func processProjectRecord(ctx context.Context, kvStore recordKV, key string, fie
 		slog.DebugContext(ctx, "record already renamed, repairing slug index", "key", key)
 	}
 
-	return writeSlugIndex(ctx, kvStore, key, oldSlug, newSlug, dryRun)
+	return deleteOldSlugIndex(ctx, kvStore, key, oldSlug, dryRun)
 }
 
-// slugIndexKV is the subset of jetstream.KeyValue used by checkSlugIndexCollision and writeSlugIndex.
+// slugIndexKV is the subset of jetstream.KeyValue used by reserveSlugIndex and deleteOldSlugIndex.
 type slugIndexKV interface {
 	Get(ctx context.Context, key string) (jetstream.KeyValueEntry, error)
 	Create(ctx context.Context, key string, value []byte, opts ...jetstream.KVCreateOpt) (uint64, error)
 	Delete(ctx context.Context, key string, opts ...jetstream.KVDeleteOpt) error
 }
 
-// checkSlugIndexCollision hard-fails if "slug/<newSlug>" already exists and
-// points at a uid other than the record being processed, so a rename never
-// silently clobbers another project's lookup mapping.
-func checkSlugIndexCollision(ctx context.Context, kv slugIndexKV, uid, newSlug string) error {
-	existing, err := kv.Get(ctx, "slug/"+newSlug)
-	switch {
-	case err == nil:
-		if string(existing.Value()) != uid {
-			return fmt.Errorf("%w: slug/%s is indexed to %q, not %q", errSlugIndexCollision, newSlug, existing.Value(), uid)
-		}
-		return nil
-	case errors.Is(err, jetstream.ErrKeyNotFound):
-		return nil
-	default:
-		return fmt.Errorf("failed to check slug index %q for collision: %w", newSlug, err)
-	}
-}
-
-// writeSlugIndex performs the actual index rename. checkSlugIndexCollision is
-// only a best-effort pre-flight and can race with a concurrent writer, so the
-// new key is reserved here with an atomic Create: if a concurrent writer won
-// the race and created "slug/<newSlug>" first, Create fails with
-// ErrKeyExists and the owning uid is re-checked instead of blindly
-// overwriting it. The old key is deleted only if it still maps to this uid,
-// so a concurrent writer that has since reused the old slug for another
-// project is not clobbered.
-func writeSlugIndex(ctx context.Context, kv slugIndexKV, uid, oldSlug, newSlug string, dryRun bool) error {
+// reserveSlugIndex is the authoritative check-and-claim for "slug/<newSlug>".
+// In dry-run mode it performs a non-mutating Get-based check, since Create
+// would actually write. In apply mode it atomically reserves the key with
+// Create: if a concurrent writer won the race and created the key first,
+// Create fails with ErrKeyExists and the owning uid is re-checked instead of
+// blindly overwriting it.
+func reserveSlugIndex(ctx context.Context, kv slugIndexKV, uid, newSlug string, dryRun bool) error {
 	if dryRun {
-		slog.InfoContext(ctx, "dry run: would reconcile slug index",
-			"uid", uid, "from", "slug/"+oldSlug, "to", "slug/"+newSlug)
-		return nil
+		existing, err := kv.Get(ctx, "slug/"+newSlug)
+		switch {
+		case err == nil:
+			if string(existing.Value()) != uid {
+				return fmt.Errorf("%w: slug/%s is indexed to %q, not %q", errSlugIndexCollision, newSlug, existing.Value(), uid)
+			}
+			return nil
+		case errors.Is(err, jetstream.ErrKeyNotFound):
+			return nil
+		default:
+			return fmt.Errorf("failed to check slug index %q for collision: %w", newSlug, err)
+		}
 	}
 
 	if _, err := kv.Create(ctx, "slug/"+newSlug, []byte(uid)); err != nil {
@@ -711,6 +702,18 @@ func writeSlugIndex(ctx context.Context, kv slugIndexKV, uid, oldSlug, newSlug s
 			return fmt.Errorf("%w: slug/%s is indexed to %q, not %q", errSlugIndexCollision, newSlug, existing.Value(), uid)
 		}
 	}
+	return nil
+}
+
+// deleteOldSlugIndex removes "slug/<oldSlug>" only if it still maps to uid,
+// using a revision-conditional delete so a writer that reassigns the key
+// between this check and the delete causes a conflict error instead of
+// losing that writer's mapping.
+func deleteOldSlugIndex(ctx context.Context, kv slugIndexKV, uid, oldSlug string, dryRun bool) error {
+	if dryRun {
+		slog.InfoContext(ctx, "dry run: would delete stale slug index", "uid", uid, "key", "slug/"+oldSlug)
+		return nil
+	}
 
 	existingOld, err := kv.Get(ctx, "slug/"+oldSlug)
 	switch {
@@ -720,7 +723,7 @@ func writeSlugIndex(ctx context.Context, kv slugIndexKV, uid, oldSlug, newSlug s
 				"uid", uid, "key", "slug/"+oldSlug)
 			return nil
 		}
-		if err := kv.Delete(ctx, "slug/"+oldSlug); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+		if err := kv.Delete(ctx, "slug/"+oldSlug, jetstream.LastRevision(existingOld.Revision())); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
 			return fmt.Errorf("failed to delete stale slug index %q: %w", oldSlug, err)
 		}
 	case errors.Is(err, jetstream.ErrKeyNotFound):

--- a/cmd/project-cli/commands/sync/rename_project_slug_test.go
+++ b/cmd/project-cli/commands/sync/rename_project_slug_test.go
@@ -196,14 +196,14 @@ func TestBuildOSQuery_containsOldSlug(t *testing.T) {
 	}
 }
 
-// reconcile runs the same collision-then-write sequence processProjectRecord
-// uses to keep the slug index in sync (checkSlugIndexCollision, then
-// writeSlugIndex).
+// reconcile runs the same reserve-then-delete sequence processProjectRecord
+// uses to keep the slug index in sync (reserveSlugIndex, then
+// deleteOldSlugIndex).
 func reconcile(ctx context.Context, kv recordKV, uid, oldSlug, newSlug string, dryRun bool) error {
-	if err := checkSlugIndexCollision(ctx, kv, uid, newSlug); err != nil {
+	if err := reserveSlugIndex(ctx, kv, uid, newSlug, dryRun); err != nil {
 		return err
 	}
-	return writeSlugIndex(ctx, kv, uid, oldSlug, newSlug, dryRun)
+	return deleteOldSlugIndex(ctx, kv, uid, oldSlug, dryRun)
 }
 
 func TestReconcileProjectSlugIndex(t *testing.T) {
@@ -267,28 +267,23 @@ func TestReconcileProjectSlugIndex(t *testing.T) {
 		}
 	})
 
-	t.Run("catches a collision that appears after the check-collision pre-flight", func(t *testing.T) {
+	t.Run("reserveSlugIndex catches a collision from a concurrent writer", func(t *testing.T) {
 		// Simulates a concurrent writer creating slug/new-slug for another
-		// project between checkSlugIndexCollision's Get and writeSlugIndex's
-		// write; writeSlugIndex's own atomic Create must still catch it.
+		// project just before reserveSlugIndex's atomic Create runs.
 		kv := newFakeRecordKV(map[string][]byte{
 			"slug/old-slug": []byte(uid),
+			"slug/new-slug": []byte(otherUID),
 		})
-		kv.entries["slug/new-slug"] = []byte(otherUID)
-		kv.revisions["slug/new-slug"] = 1
-		err := writeSlugIndex(context.Background(), kv, uid, "old-slug", "new-slug", false)
+		err := reserveSlugIndex(context.Background(), kv, uid, "new-slug", false)
 		if !errors.Is(err, errSlugIndexCollision) {
 			t.Fatalf("expected errSlugIndexCollision, got %v", err)
 		}
 		if got := kv.entries["slug/new-slug"]; string(got) != otherUID {
 			t.Errorf("expected slug/new-slug to remain owned by the other project, got %q", got)
 		}
-		if got, ok := kv.entries["slug/old-slug"]; !ok || string(got) != uid {
-			t.Errorf("expected slug/old-slug to remain untouched, got %q (present=%v)", got, ok)
-		}
 	})
 
-	t.Run("does not delete the old index key if it was reassigned to another project", func(t *testing.T) {
+	t.Run("deleteOldSlugIndex does not delete the old index key if it was reassigned to another project", func(t *testing.T) {
 		// Simulates a concurrent writer reusing old-slug for another project
 		// after this record's field was renamed but before the index was
 		// reconciled; the stale-looking slug/old-slug entry must be left in
@@ -296,14 +291,11 @@ func TestReconcileProjectSlugIndex(t *testing.T) {
 		kv := newFakeRecordKV(map[string][]byte{
 			"slug/old-slug": []byte(otherUID),
 		})
-		if err := writeSlugIndex(context.Background(), kv, uid, "old-slug", "new-slug", false); err != nil {
+		if err := deleteOldSlugIndex(context.Background(), kv, uid, "old-slug", false); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if got, ok := kv.entries["slug/old-slug"]; !ok || string(got) != otherUID {
 			t.Errorf("expected slug/old-slug to remain owned by the other project, got %q (present=%v)", got, ok)
-		}
-		if got, ok := kv.entries["slug/new-slug"]; !ok || string(got) != uid {
-			t.Errorf("expected slug/new-slug to map to %q, got %q (present=%v)", uid, got, ok)
 		}
 	})
 }

--- a/cmd/project-cli/commands/sync/rename_project_slug_test.go
+++ b/cmd/project-cli/commands/sync/rename_project_slug_test.go
@@ -63,10 +63,13 @@ func (f *fakeRecordKV) Update(_ context.Context, key string, value []byte, revis
 	return f.revisions[key], nil
 }
 
-func (f *fakeRecordKV) Put(_ context.Context, key string, value []byte) (uint64, error) {
+func (f *fakeRecordKV) Create(_ context.Context, key string, value []byte, _ ...jetstream.KVCreateOpt) (uint64, error) {
+	if _, ok := f.entries[key]; ok {
+		return 0, jetstream.ErrKeyExists
+	}
 	f.entries[key] = value
-	f.revisions[key]++
-	return f.revisions[key], nil
+	f.revisions[key] = 1
+	return 1, nil
 }
 
 func (f *fakeRecordKV) Delete(_ context.Context, key string, _ ...jetstream.KVDeleteOpt) error {
@@ -261,6 +264,46 @@ func TestReconcileProjectSlugIndex(t *testing.T) {
 		}
 		if got, ok := kv.entries["slug/old-slug"]; !ok || string(got) != uid {
 			t.Errorf("expected slug/old-slug to remain untouched during dry run, got %q (present=%v)", got, ok)
+		}
+	})
+
+	t.Run("catches a collision that appears after the check-collision pre-flight", func(t *testing.T) {
+		// Simulates a concurrent writer creating slug/new-slug for another
+		// project between checkSlugIndexCollision's Get and writeSlugIndex's
+		// write; writeSlugIndex's own atomic Create must still catch it.
+		kv := newFakeRecordKV(map[string][]byte{
+			"slug/old-slug": []byte(uid),
+		})
+		kv.entries["slug/new-slug"] = []byte(otherUID)
+		kv.revisions["slug/new-slug"] = 1
+		err := writeSlugIndex(context.Background(), kv, uid, "old-slug", "new-slug", false)
+		if !errors.Is(err, errSlugIndexCollision) {
+			t.Fatalf("expected errSlugIndexCollision, got %v", err)
+		}
+		if got := kv.entries["slug/new-slug"]; string(got) != otherUID {
+			t.Errorf("expected slug/new-slug to remain owned by the other project, got %q", got)
+		}
+		if got, ok := kv.entries["slug/old-slug"]; !ok || string(got) != uid {
+			t.Errorf("expected slug/old-slug to remain untouched, got %q (present=%v)", got, ok)
+		}
+	})
+
+	t.Run("does not delete the old index key if it was reassigned to another project", func(t *testing.T) {
+		// Simulates a concurrent writer reusing old-slug for another project
+		// after this record's field was renamed but before the index was
+		// reconciled; the stale-looking slug/old-slug entry must be left in
+		// place rather than deleted out from under its new owner.
+		kv := newFakeRecordKV(map[string][]byte{
+			"slug/old-slug": []byte(otherUID),
+		})
+		if err := writeSlugIndex(context.Background(), kv, uid, "old-slug", "new-slug", false); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got, ok := kv.entries["slug/old-slug"]; !ok || string(got) != otherUID {
+			t.Errorf("expected slug/old-slug to remain owned by the other project, got %q (present=%v)", got, ok)
+		}
+		if got, ok := kv.entries["slug/new-slug"]; !ok || string(got) != uid {
+			t.Errorf("expected slug/new-slug to map to %q, got %q (present=%v)", uid, got, ok)
 		}
 	})
 }

--- a/cmd/project-cli/commands/sync/rename_project_slug_test.go
+++ b/cmd/project-cli/commands/sync/rename_project_slug_test.go
@@ -4,8 +4,79 @@
 package sync
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
 )
+
+type fakeKVEntry struct {
+	key      string
+	value    []byte
+	revision uint64
+}
+
+func (f fakeKVEntry) Bucket() string                  { return "projects" }
+func (f fakeKVEntry) Key() string                     { return f.key }
+func (f fakeKVEntry) Value() []byte                   { return f.value }
+func (f fakeKVEntry) Revision() uint64                { return f.revision }
+func (f fakeKVEntry) Created() time.Time              { return time.Time{} }
+func (f fakeKVEntry) Delta() uint64                   { return 0 }
+func (f fakeKVEntry) Operation() jetstream.KeyValueOp { return jetstream.KeyValuePut }
+
+// fakeRecordKV implements recordKV over an in-memory map keyed by both
+// record keys (e.g. project uids) and "slug/<slug>" index keys, so it can
+// back processProjectRecord/processKVRecord tests without a full
+// jetstream.KeyValue fake.
+type fakeRecordKV struct {
+	entries   map[string][]byte
+	revisions map[string]uint64
+}
+
+func newFakeRecordKV(entries map[string][]byte) *fakeRecordKV {
+	if entries == nil {
+		entries = map[string][]byte{}
+	}
+	revisions := make(map[string]uint64, len(entries))
+	for k := range entries {
+		revisions[k] = 1
+	}
+	return &fakeRecordKV{entries: entries, revisions: revisions}
+}
+
+func (f *fakeRecordKV) Get(_ context.Context, key string) (jetstream.KeyValueEntry, error) {
+	v, ok := f.entries[key]
+	if !ok {
+		return nil, jetstream.ErrKeyNotFound
+	}
+	return fakeKVEntry{key: key, value: v, revision: f.revisions[key]}, nil
+}
+
+func (f *fakeRecordKV) Update(_ context.Context, key string, value []byte, revision uint64) (uint64, error) {
+	if f.revisions[key] != revision {
+		return 0, jetstream.ErrKeyExists
+	}
+	f.entries[key] = value
+	f.revisions[key]++
+	return f.revisions[key], nil
+}
+
+func (f *fakeRecordKV) Put(_ context.Context, key string, value []byte) (uint64, error) {
+	f.entries[key] = value
+	f.revisions[key]++
+	return f.revisions[key], nil
+}
+
+func (f *fakeRecordKV) Delete(_ context.Context, key string, _ ...jetstream.KVDeleteOpt) error {
+	if _, ok := f.entries[key]; !ok {
+		return jetstream.ErrKeyNotFound
+	}
+	delete(f.entries, key)
+	delete(f.revisions, key)
+	return nil
+}
 
 func TestResolveSlugs_fromFlags(t *testing.T) {
 	old, new, err := resolveSlugs("old-slug", "new-slug", nil)
@@ -120,6 +191,166 @@ func TestBuildOSQuery_containsOldSlug(t *testing.T) {
 			t.Errorf("expected should clause for field %q, but it was missing", required)
 		}
 	}
+}
+
+// reconcile runs the same collision-then-write sequence processProjectRecord
+// uses to keep the slug index in sync (checkSlugIndexCollision, then
+// writeSlugIndex).
+func reconcile(ctx context.Context, kv recordKV, uid, oldSlug, newSlug string, dryRun bool) error {
+	if err := checkSlugIndexCollision(ctx, kv, uid, newSlug); err != nil {
+		return err
+	}
+	return writeSlugIndex(ctx, kv, uid, oldSlug, newSlug, dryRun)
+}
+
+func TestReconcileProjectSlugIndex(t *testing.T) {
+	const uid = "00000000-0000-0000-0000-000000000001"
+	const otherUID = "00000000-0000-0000-0000-000000000002"
+
+	t.Run("renames the index key", func(t *testing.T) {
+		kv := newFakeRecordKV(map[string][]byte{
+			"slug/old-slug": []byte(uid),
+		})
+		if err := reconcile(context.Background(), kv, uid, "old-slug", "new-slug", false); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got, ok := kv.entries["slug/new-slug"]; !ok || string(got) != uid {
+			t.Errorf("expected slug/new-slug to map to %q, got %q (present=%v)", uid, got, ok)
+		}
+		if _, ok := kv.entries["slug/old-slug"]; ok {
+			t.Errorf("expected stale slug/old-slug to be deleted")
+		}
+	})
+
+	t.Run("is idempotent when the old index key is already gone", func(t *testing.T) {
+		kv := newFakeRecordKV(nil)
+		if err := reconcile(context.Background(), kv, uid, "old-slug", "new-slug", false); err != nil {
+			t.Fatalf("unexpected error re-running on an already-migrated index: %v", err)
+		}
+		if got, ok := kv.entries["slug/new-slug"]; !ok || string(got) != uid {
+			t.Errorf("expected slug/new-slug to map to %q, got %q (present=%v)", uid, got, ok)
+		}
+	})
+
+	t.Run("fails on collision with another project's index", func(t *testing.T) {
+		kv := newFakeRecordKV(map[string][]byte{
+			"slug/old-slug": []byte(uid),
+			"slug/new-slug": []byte(otherUID),
+		})
+		err := reconcile(context.Background(), kv, uid, "old-slug", "new-slug", false)
+		if !errors.Is(err, errSlugIndexCollision) {
+			t.Fatalf("expected errSlugIndexCollision, got %v", err)
+		}
+		if got := kv.entries["slug/new-slug"]; string(got) != otherUID {
+			t.Errorf("expected slug/new-slug to remain untouched at %q, got %q", otherUID, got)
+		}
+		if got, ok := kv.entries["slug/old-slug"]; !ok || string(got) != uid {
+			t.Errorf("expected slug/old-slug to remain untouched, got %q (present=%v)", got, ok)
+		}
+	})
+
+	t.Run("dry run makes no writes", func(t *testing.T) {
+		kv := newFakeRecordKV(map[string][]byte{
+			"slug/old-slug": []byte(uid),
+		})
+		if err := reconcile(context.Background(), kv, uid, "old-slug", "new-slug", true); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := kv.entries["slug/new-slug"]; ok {
+			t.Errorf("expected no write to slug/new-slug during dry run")
+		}
+		if got, ok := kv.entries["slug/old-slug"]; !ok || string(got) != uid {
+			t.Errorf("expected slug/old-slug to remain untouched during dry run, got %q (present=%v)", got, ok)
+		}
+	})
+}
+
+func TestProcessProjectRecord(t *testing.T) {
+	const uid = "00000000-0000-0000-0000-000000000001"
+	const otherUID = "00000000-0000-0000-0000-000000000002"
+	fields := []string{"slug"}
+
+	t.Run("forward match renames the field and the index", func(t *testing.T) {
+		kv := newFakeRecordKV(map[string][]byte{
+			uid:             []byte(`{"slug":"old-slug"}`),
+			"slug/old-slug": []byte(uid),
+		})
+		if err := processProjectRecord(context.Background(), kv, uid, fields, "old-slug", "new-slug", false); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := string(kv.entries[uid]); got != `{"slug":"new-slug"}` {
+			t.Errorf("expected record slug field renamed, got %s", got)
+		}
+		if got, ok := kv.entries["slug/new-slug"]; !ok || string(got) != uid {
+			t.Errorf("expected slug/new-slug to map to %q, got %q (present=%v)", uid, got, ok)
+		}
+		if _, ok := kv.entries["slug/old-slug"]; ok {
+			t.Errorf("expected stale slug/old-slug to be deleted")
+		}
+	})
+
+	t.Run("repairs a stale index when the field is already renamed", func(t *testing.T) {
+		kv := newFakeRecordKV(map[string][]byte{
+			uid:             []byte(`{"slug":"new-slug"}`),
+			"slug/old-slug": []byte(uid),
+		})
+		if err := processProjectRecord(context.Background(), kv, uid, fields, "old-slug", "new-slug", false); err != nil {
+			t.Fatalf("unexpected error repairing an already-migrated record: %v", err)
+		}
+		if got, ok := kv.entries["slug/new-slug"]; !ok || string(got) != uid {
+			t.Errorf("expected slug/new-slug to map to %q, got %q (present=%v)", uid, got, ok)
+		}
+		if _, ok := kv.entries["slug/old-slug"]; ok {
+			t.Errorf("expected stale slug/old-slug to be deleted")
+		}
+	})
+
+	t.Run("skips a record whose slug matches neither old nor new", func(t *testing.T) {
+		kv := newFakeRecordKV(map[string][]byte{
+			uid: []byte(`{"slug":"unrelated-slug"}`),
+		})
+		err := processProjectRecord(context.Background(), kv, uid, fields, "old-slug", "new-slug", false)
+		if !errors.Is(err, errSlugMismatch) {
+			t.Fatalf("expected errSlugMismatch, got %v", err)
+		}
+	})
+
+	t.Run("fails without renaming the field when the index has a collision", func(t *testing.T) {
+		kv := newFakeRecordKV(map[string][]byte{
+			uid:             []byte(`{"slug":"old-slug"}`),
+			"slug/old-slug": []byte(uid),
+			"slug/new-slug": []byte(otherUID),
+		})
+		err := processProjectRecord(context.Background(), kv, uid, fields, "old-slug", "new-slug", false)
+		if !errors.Is(err, errSlugIndexCollision) {
+			t.Fatalf("expected errSlugIndexCollision, got %v", err)
+		}
+		if got := string(kv.entries[uid]); got != `{"slug":"old-slug"}` {
+			t.Errorf("expected record field left untouched after collision, got %s", got)
+		}
+		if got := kv.entries["slug/new-slug"]; string(got) != otherUID {
+			t.Errorf("expected slug/new-slug to remain untouched at %q, got %q", otherUID, got)
+		}
+	})
+
+	t.Run("dry run makes no writes to the record or the index", func(t *testing.T) {
+		kv := newFakeRecordKV(map[string][]byte{
+			uid:             []byte(`{"slug":"old-slug"}`),
+			"slug/old-slug": []byte(uid),
+		})
+		if err := processProjectRecord(context.Background(), kv, uid, fields, "old-slug", "new-slug", true); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := string(kv.entries[uid]); got != `{"slug":"old-slug"}` {
+			t.Errorf("expected no write to record during dry run, got %s", got)
+		}
+		if _, ok := kv.entries["slug/new-slug"]; ok {
+			t.Errorf("expected no write to slug/new-slug during dry run")
+		}
+		if _, ok := kv.entries["slug/old-slug"]; !ok {
+			t.Errorf("expected slug/old-slug to remain untouched during dry run")
+		}
+	})
 }
 
 func assertEqual[T comparable](t *testing.T, want, got []T) {


### PR DESCRIPTION
## Summary

- `sync rename-project-slug` renamed a project's `slug` field across NATS KV buckets but never touched the `projects` bucket's secondary `slug/<slug>` -> uid lookup index used by `GetProjectUIDFromSlug` (and thus the `lfx.projects-api.slug_to_uid` NATS RPC). A completed rename in prod left the new slug unresolvable via that RPC while the old slug kept resolving.
- Added `processProjectRecord`, used only for the `projects` bucket. It dispatches off the record's **observed current slug** rather than whether the current run performed the field write:
  - current slug == old slug -> rename field, then reconcile index
  - current slug == new slug (already renamed by a prior partial run) -> repair the index only
  - neither -> skip
  This fixes the underlying bug class: a record left inconsistent by a partial failure (field renamed, index stale) is repaired on rerun instead of becoming permanently invisible to the migration.
- Added `checkSlugIndexCollision`, run as a pre-flight **before any mutation**. If the new slug's index already points at a different uid, the operation hard-fails and neither the record's field nor the index is touched — no silent clobbering of another project's slug mapping.
- Added a dry-run log line describing the planned index rename.
- Documented the behavior in `cmd/project-cli/README.md`.
- New unit tests: `TestReconcileProjectSlugIndex`, `TestProcessProjectRecord` (forward-rename, repair-only, collision, dry-run cases).

## Live verification

Connected to a dev cluster via `kubectl port-forward` to NATS, ran the reworked code directly against a real dev project record, and verified against the actual `lfx.projects-api.slug_to_uid` RPC served by the running project-service — not just direct KV reads.

**1. Baseline**
```
$ nats request lfx.projects-api.slug_to_uid <old-slug>
<project-uid>
```

**2. Dry run (`<old-slug>` -> `<new-slug>`)**
```
dry run: would reconcile slug index uid=<project-uid>... from=slug/<old-slug> to=slug/<new-slug>
dry run stats: &{Total:40 Updated:1 Skipped:39 Failed:0}
```
Record and index confirmed untouched after dry run.

**3. Apply (`<old-slug>` -> `<new-slug>`)**
```
apply stats: &{Total:40 Updated:1 Skipped:39 Failed:0}
record.slug: "<old-slug>" -> "<new-slug>"
slug/<old-slug> -> (deleted)
slug/<new-slug> -> <project-uid>
```

RPC check:
```
$ nats request lfx.projects-api.slug_to_uid <new-slug>
<project-uid>

$ nats request lfx.projects-api.slug_to_uid <old-slug> --raw
nil body
```
New slug resolves via the live RPC; old slug correctly no longer resolves.

**4. Repair-only rerun** (same args, field already renamed)
```
repair-only rerun stats: &{Total:40 Updated:1 Skipped:39 Failed:0}
```
Took the "already renamed" branch and left state unchanged/idempotent — this is the exact scenario that was unrecoverable before the fix.

**5. Restore (`<new-slug>` -> `<old-slug>`)**
```
restore stats: &{Total:40 Updated:1 Skipped:39 Failed:0}
```
RPC checks confirmed old slug resolves again and the temp slug no longer does. Dev fully restored, no residue left behind.

Collision and dry-run-makes-no-writes cases are covered by unit tests against fakes (not exercised live, since deliberately colliding two real projects' slugs wasn't practical).

## Production repair

A prior prod migration for one already-completed rename had left its secondary index stale (old slug's index key still resolving, new slug's index key missing) — exactly the bug this PR fixes. Verified via `kubectl port-forward` to prod NATS and a scoped, projects-bucket-only run of the reworked migration code (bypassing OpenSearch/other buckets entirely): `Total:1346 Updated:1 Skipped:1345 Failed:0`. Confirmed via direct KV reads and the live `lfx.projects-api.slug_to_uid` RPC that the new slug now resolves and the old slug no longer does.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./cmd/project-cli/... -race -cover`
- [x] Live verification on dev (dry-run, apply, repair-only rerun, restore — all confirmed via KV + RPC)
- [x] Applied and verified in prod for the one pre-existing stale-index case